### PR TITLE
nickname 유니크 키 제거 및 중복 검증 로직 제거

### DIFF
--- a/prisma/migrations/20251208083147_remove_user_unique_nickname/migration.sql
+++ b/prisma/migrations/20251208083147_remove_user_unique_nickname/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "public"."users_nickname_key";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,7 +49,7 @@ model User {
   id             Int       @id @default(autoincrement())
   username       String?   @unique @db.VarChar(20)
   hashedPassword String?   @map("hashed_password") @db.VarChar(60)
-  nickname       String    @unique @db.VarChar(30)
+  nickname       String    @db.VarChar(30)
   provider       Provider?
   providerId     String?   @map("provider_id") @db.VarChar(50)
   createdAt      DateTime  @default(now()) @map("created_at")

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -3,7 +3,7 @@ import { UsersService } from 'src/users/users.service';
 import { SignupRequestDto } from './dto/requests/signup-request.dto';
 import { JwtPayload } from './interfaces/jwt-payload.interface';
 import { TokenService } from './token/token.service';
-import { userData } from './interfaces/user-data.interface';
+import { UserData } from './interfaces/user-data.interface';
 import { TokenDto } from './dto/responses/token.dto';
 import { AccessTokenDto } from './dto/responses/access-token.dto';
 import { PasswordEncoderUtil } from 'src/common/hashing/password-encoder.util';
@@ -19,24 +19,13 @@ export class AuthService {
 
   // 회원가입
   async signup(signupRequestDto: SignupRequestDto): Promise<void> {
-    const existingUser = await this.userService.findUserByUsernameOrNickname(
-      signupRequestDto.username,
-      signupRequestDto.nickname,
-    );
+    const existingUser = await this.userService.findUserByUsername(signupRequestDto.username);
 
     if (existingUser) {
-      if (existingUser.username === signupRequestDto.username) {
-        throw new ConflictException({
-          code: USER_ERROR_CODES.USERNAME_ALREADY_EXISTS,
-          errors: [AUTH_DOMAIN_ERRORS.USERNAME_ALREADY_EXISTS],
-        });
-      }
-      if (existingUser.nickname === signupRequestDto.nickname) {
-        throw new ConflictException({
-          code: USER_ERROR_CODES.NICKNAME_ALREADY_EXISTS,
-          errors: [AUTH_DOMAIN_ERRORS.NICKNAME_ALREADY_EXISTS],
-        });
-      }
+      throw new ConflictException({
+        code: USER_ERROR_CODES.USERNAME_ALREADY_EXISTS,
+        errors: [AUTH_DOMAIN_ERRORS.USERNAME_ALREADY_EXISTS],
+      });
     }
 
     const hashedPassword = await PasswordEncoderUtil.hash(signupRequestDto.password);
@@ -51,7 +40,7 @@ export class AuthService {
   }
 
   // 유저 검증
-  async validateUser(username: string, password: string): Promise<userData | null> {
+  async validateUser(username: string, password: string): Promise<UserData | null> {
     const user = await this.userService.findUserByUsername(username);
     if (!user || !user.hashedPassword) return null;
 
@@ -63,7 +52,7 @@ export class AuthService {
   }
 
   // 로그인
-  async login(userData: userData): Promise<TokenDto> {
+  async login(userData: UserData): Promise<TokenDto> {
     const payload: JwtPayload = {
       sub: userData.id,
       nickname: userData.nickname,
@@ -94,14 +83,6 @@ export class AuthService {
 
   // 소셜 로그인
   async socialLogin(socialUser: SocialLoginPayload): Promise<TokenDto> {
-    const userNickname = await this.userService.findSocialUser(socialUser.nickname);
-    if (userNickname && userNickname.nickname !== socialUser.nickname) {
-      throw new ConflictException({
-        code: USER_ERROR_CODES.NICKNAME_ALREADY_EXISTS,
-        errors: [AUTH_DOMAIN_ERRORS.NICKNAME_ALREADY_EXISTS],
-      });
-    }
-
     let user = await this.userService.findUserByProvider(
       socialUser.provider,
       socialUser.providerId,

--- a/src/auth/auth.swagger.ts
+++ b/src/auth/auth.swagger.ts
@@ -78,7 +78,7 @@ const badRequestErrors = (keys: (keyof typeof badRequestExamples)[]) =>
 const conflictErrors = () =>
   ApiResponse({
     status: 409,
-    description: '이미 사용 중인 아이디 또는 닉네임입니다.',
+    description: '이미 사용 중인 아이디입니다.',
     content: {
       'application/json': {
         examples: {
@@ -91,19 +91,6 @@ const conflictErrors = () =>
                 {
                   field: 'username',
                   reason: ['This username already exists.'],
-                },
-              ],
-            },
-          },
-          NicknameAlreadyExists: {
-            summary: 'NicknameAlreadyExists',
-            value: {
-              status: 409,
-              code: 'NICKNAME_ALREADY_EXISTS',
-              errors: [
-                {
-                  field: 'nickname',
-                  reason: ['This nickname already exists.'],
                 },
               ],
             },

--- a/src/auth/constants/auth.constants.ts
+++ b/src/auth/constants/auth.constants.ts
@@ -1,6 +1,5 @@
 export const USER_ERROR_CODES = {
   USERNAME_ALREADY_EXISTS: 'USERNAME_ALREADY_EXISTS',
-  NICKNAME_ALREADY_EXISTS: 'NICKNAME_ALREADY_EXISTS',
 } as const;
 
 export const AUTH_ERROR_CODES = {
@@ -30,9 +29,5 @@ export const AUTH_DOMAIN_ERRORS: Record<string, { field: string; reason: string 
   USERNAME_ALREADY_EXISTS: {
     field: 'username',
     reason: 'This username is already in use',
-  },
-  NICKNAME_ALREADY_EXISTS: {
-    field: 'nickname',
-    reason: 'This nickname is already in use',
   },
 };

--- a/src/auth/interfaces/authenticated-request.interface.ts
+++ b/src/auth/interfaces/authenticated-request.interface.ts
@@ -1,6 +1,6 @@
 import { Request } from 'express';
-import { userData } from './user-data.interface';
+import { UserData } from './user-data.interface';
 
 export interface AuthenticatedRequest extends Request {
-  user: userData;
+  user: UserData;
 }

--- a/src/auth/interfaces/user-data.interface.ts
+++ b/src/auth/interfaces/user-data.interface.ts
@@ -1,4 +1,4 @@
-export interface userData {
+export interface UserData {
   id: number;
   username: string | null;
   nickname: string;

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -34,10 +34,4 @@ export class UsersRepository {
       },
     });
   }
-
-  async findByNickname(nickname: string): Promise<User | null> {
-    return this.prisma.user.findUnique({
-      where: { nickname },
-    });
-  }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -9,12 +9,7 @@ import { Provider } from '@prisma/client';
 export class UsersService {
   constructor(private readonly usersRepository: UsersRepository) {}
 
-  // 아이디 또는 닉네임으로 유저 조회
-  async findUserByUsernameOrNickname(username: string, nickname: string): Promise<User | null> {
-    return this.usersRepository.findByUsernameOrNickname(username, nickname);
-  }
-
-  // 비밀번호 확인용 유저 조회
+  // 로그인 아이디(Username)로 조회
   async findUserByUsername(username: string): Promise<User | null> {
     return this.usersRepository.findOneByUsername(username);
   }
@@ -24,14 +19,9 @@ export class UsersService {
     return this.usersRepository.createUser(userData);
   }
 
-  // 소셜 로그인 유저ID 조회
+  // Provider로 소셜 사용자 조회
   async findUserByProvider(provider: Provider, providerId: string): Promise<User | null> {
     return this.usersRepository.findUserByProvider(provider, providerId);
-  }
-
-  // 소셜 로그인 유저 조회
-  async findSocialUser(nickname: string): Promise<User | null> {
-    return this.usersRepository.findByNickname(nickname);
   }
 
   // 소셜 로그인 유저 생성


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #42 

## 📝 작업 내용

- User 테이블 nickname컬럼의 UNIQUE 키 삭제
- nickname관련 중복 검증 로직 제거
- 타입명 userdata → UserData로 네이밍 수정

## 💬 리뷰 요구사항

- 친구 추가나 채팅 멘션 기능을 사용 할 때 nickname + id(PK)를 사용하기로 했습니다.
- 이러한 방식도 괜찮은지 코멘트 부탁드립니다!