### PR TITLE
Room API 401 예외 상황별 구체화

### DIFF
--- a/src/rooms/rooms.swagger.ts
+++ b/src/rooms/rooms.swagger.ts
@@ -64,8 +64,16 @@ const unauthorizedError = () =>
     description: '권한 없음',
     type: StandardErrorResponseDto,
     examples: {
-      unauthorized: {
-        summary: '로그인 필요',
+      accessTokenMissing: {
+        summary: 'Access token 없음',
+        value: { status: 401, code: 'ACCESS_TOKEN_MISSING', errors: [] },
+      },
+      invalidAccessToken: {
+        summary: '유효하지 않은 Access token',
+        value: { status: 401, code: 'INVALID_ACCESS_TOKEN', errors: [] },
+      },
+      expiredAccessToken: {
+        summary: '만료된 Access token',
         value: { status: 401, code: 'EXPIRED_ACCESS_TOKEN', errors: [] },
       },
     },
@@ -78,6 +86,7 @@ export const ApiRoom = {
       ApiOperation({ summary: '새로운 방 생성' }),
       ApiResponse({ status: 201, description: '방 생성 성공', type: ResRoomDto }),
       badRequestErrors(),
+      unauthorizedError(),
     ),
 
   getAllRooms: () =>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #48 

## 📝 작업 내용

- Room 도메인 Swagger API 문서의 401 Unauthorized 예외를 상황별로 구체화했습니다.
- 방 생성 API에서 누락된 401 예외를 추가했습니다.