### PR TITLE
WaitingGateway와 WaitingService 책임 분리

### DIFF
--- a/src/waiting/waiting.gateway.ts
+++ b/src/waiting/waiting.gateway.ts
@@ -9,16 +9,11 @@ import {
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 import { WaitingService } from './waiting.service';
-import { UseFilters, UsePipes, ValidationPipe, Logger } from '@nestjs/common';
+import { UseFilters, UsePipes, ValidationPipe } from '@nestjs/common';
 import { SocketExceptionFilter } from 'src/common/filters/socket-exception.filter';
-import {
-  WAITING_ERROR_CODES,
-  WAITING_EVENTS,
-  WAITING_CONSTANTS,
-} from './constants/waiting.constant';
+import { WAITING_ERROR_CODES, WAITING_EVENTS } from './constants/waiting.constant';
 import { wsError } from 'src/common/utils/ws-error.util';
 import { SendMessageDto } from 'src/chat/dtos/requests/send-message.dto';
-import { ChatService } from 'src/chat/chat.service';
 import { JwtService } from '@nestjs/jwt';
 import { JoinRoomDto } from './dtos/requests/join-room.dto';
 import { ChangeTeamDto } from './dtos/requests/change-team.dto';
@@ -27,10 +22,6 @@ import { UpdateOutfitDto } from './dtos/requests/update-outfit.dto';
 import { UpdateSettingsDto } from './dtos/requests/update-settings.dto';
 import { KickUserDto } from './dtos/requests/kick-user.dto';
 import { NudgeUserDto } from './dtos/requests/nudge-user.dto';
-import { GameStateStore } from 'src/game-state/game-state.store';
-import { GamePhase } from 'src/game-state/interfaces/game-state.interface';
-import { GAME_EVENTS } from 'src/game/constants/game.constant';
-import { EventEmitter2 } from '@nestjs/event-emitter';
 
 interface JwtPayload {
   sub: string;
@@ -70,14 +61,10 @@ interface ClientData {
 })
 export class WaitingGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @WebSocketServer() server: Server;
-  private readonly logger = new Logger(WaitingGateway.name);
 
   constructor(
     private readonly waitingService: WaitingService,
-    private readonly chatService: ChatService,
     private readonly jwtService: JwtService,
-    private readonly gameStateStore: GameStateStore,
-    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   handleConnection(client: Socket) {
@@ -100,7 +87,6 @@ export class WaitingGateway implements OnGatewayConnection, OnGatewayDisconnect 
         userId: Number(payload.sub),
         nickname: payload.nickname,
       };
-      this.logger.log(`User connected: ${payload.nickname} (${client.id})`);
     } catch (err: unknown) {
       const isTokenExpired = err instanceof Error && err.name === 'TokenExpiredError';
       const error = wsError(
@@ -118,7 +104,6 @@ export class WaitingGateway implements OnGatewayConnection, OnGatewayDisconnect 
     const data = client.data as ClientData;
 
     if (!data?.userId || !data?.roomId) {
-      this.logger.log(`User disconnected: ${client.id}`);
       return;
     }
 
@@ -156,11 +141,6 @@ export class WaitingGateway implements OnGatewayConnection, OnGatewayDisconnect 
     });
   }
 
-  private emitRoomSystemMessage(roomId: number, message: string) {
-    const systemMessage = this.chatService.createSystemMessage({ message });
-    this.server.to(`room:${roomId}`).emit(WAITING_EVENTS.ROOM_SYSTEM_MESSAGE, systemMessage);
-  }
-
   @SubscribeMessage(WAITING_EVENTS.ROOM_JOIN)
   async handleJoin(@MessageBody() body: JoinRoomDto, @ConnectedSocket() client: Socket) {
     const clientData = this.getClientData(client);
@@ -181,13 +161,18 @@ export class WaitingGateway implements OnGatewayConnection, OnGatewayDisconnect 
       }
     }
 
-    const state = await this.waitingService.joinRoom(body.roomId, clientData.userId, body.password);
+    const { state, systemMessage } = await this.waitingService.joinRoom(
+      body.roomId,
+      clientData.userId,
+      body.password,
+    );
 
     (client.data as ClientData).roomId = body.roomId;
     await client.join(`room:${body.roomId}`);
 
     this.emitPlayerListSync(body.roomId, state.players);
-    this.emitRoomSystemMessage(body.roomId, `${clientData.nickname}님이 입장했습니다.`);
+
+    this.server.to(`room:${body.roomId}`).emit(WAITING_EVENTS.ROOM_SYSTEM_MESSAGE, systemMessage);
 
     client.emit(WAITING_EVENTS.ROOM_JOIN_SUCCESS, state);
   }
@@ -280,16 +265,14 @@ export class WaitingGateway implements OnGatewayConnection, OnGatewayDisconnect 
     }
 
     const { roomId, userId } = clientData;
-    await this.waitingService.updateSettings(roomId, userId, body);
-
-    const state = await this.waitingService.getState(roomId);
+    const { state, systemMessage } = await this.waitingService.updateSettings(roomId, userId, body);
 
     this.server.to(`room:${roomId}`).emit(WAITING_EVENTS.ROOM_UPDATE_ROOM, {
       roomSettings: state.settings,
     });
 
     this.emitPlayerListSync(roomId, state.players);
-    this.emitRoomSystemMessage(roomId, '게임 설정이 변경되었습니다.');
+    this.server.to(`room:${roomId}`).emit(WAITING_EVENTS.ROOM_SYSTEM_MESSAGE, systemMessage);
   }
 
   @SubscribeMessage(WAITING_EVENTS.ROOM_KICK_USER)
@@ -300,15 +283,11 @@ export class WaitingGateway implements OnGatewayConnection, OnGatewayDisconnect 
     }
 
     const { roomId, userId } = clientData;
-
-    const playersBeforeKick = await this.waitingService.getPlayers(roomId);
-    const kickedPlayer = playersBeforeKick.find((p) => p.userId === body.targetUserId);
-
-    if (!kickedPlayer) {
-      throw wsError(404, WAITING_ERROR_CODES.PLAYER_NOT_FOUND);
-    }
-
-    await this.waitingService.kickPlayer(roomId, userId, body.targetUserId);
+    const { remainingPlayers, systemMessage } = await this.waitingService.kickPlayer(
+      roomId,
+      userId,
+      body.targetUserId,
+    );
 
     const targetClients = await this.server.in(`room:${roomId}`).fetchSockets();
     const targetClient = targetClients.find(
@@ -325,9 +304,8 @@ export class WaitingGateway implements OnGatewayConnection, OnGatewayDisconnect 
       targetClient.disconnect();
     }
 
-    const players = await this.waitingService.getPlayers(roomId);
-    this.emitPlayerListSync(roomId, players);
-    this.emitRoomSystemMessage(roomId, `${kickedPlayer.nickname}님이 강퇴되었습니다.`);
+    this.emitPlayerListSync(roomId, remainingPlayers);
+    this.server.to(`room:${roomId}`).emit(WAITING_EVENTS.ROOM_SYSTEM_MESSAGE, systemMessage);
   }
 
   @SubscribeMessage(WAITING_EVENTS.ROOM_NUDGE_USER)
@@ -365,29 +343,13 @@ export class WaitingGateway implements OnGatewayConnection, OnGatewayDisconnect 
     }
 
     const { roomId, userId } = clientData;
-
-    await this.waitingService.startGame(roomId, userId);
-
-    await this.waitingService.markRoomAsStarted(roomId);
-
-    const loadingEndTime = Date.now() + WAITING_CONSTANTS.LOADING_PHASE_DURATION_MS;
-    await this.gameStateStore.set(roomId, {
-      phase: GamePhase.LOADING,
-      endsAt: loadingEndTime,
-      currentRound: 1,
-      totalRounds: WAITING_CONSTANTS.DEFAULT_ROUNDS,
-      currentTheme: null,
-      recentThemes: [],
-      phaseContext: null,
-    });
+    const { gameState } = await this.waitingService.handleGameStart(roomId, userId);
 
     this.server.to(`room:${roomId}`).emit(WAITING_EVENTS.ROOM_UPDATE_GAME_STATE, {
-      phase: GamePhase.LOADING,
-      endsAt: loadingEndTime,
-      phaseContext: null,
+      phase: gameState.phase,
+      endsAt: gameState.endsAt,
+      phaseContext: gameState.phaseContext,
     });
-
-    this.eventEmitter.emit(GAME_EVENTS.LOADING_STARTED, { roomId });
   }
 
   @SubscribeMessage(WAITING_EVENTS.ROOM_LEAVE)

--- a/src/waiting/waiting.service.ts
+++ b/src/waiting/waiting.service.ts
@@ -10,11 +10,16 @@ import { Room } from 'src/room/entities/room.entity';
 import type { IRoomReader } from 'src/room/interfaces/room-reader.interface';
 import type { IRoomWriter } from 'src/room/interfaces/room-writer.interface';
 import { ChatService } from 'src/chat/chat.service';
+import { GameStateStore } from 'src/game-state/game-state.store';
+import { GamePhase } from 'src/game-state/interfaces/game-state.interface';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { GAME_EVENTS } from 'src/game/constants/game.constant';
 import {
   WAITING_CONSTANTS,
   WAITING_DOMAIN_ERRORS,
   WAITING_ERROR_CODES,
 } from './constants/waiting.constant';
+import { ChatMessageDto } from 'src/chat/dtos/responses/message-response.dto';
 
 @Injectable()
 export class WaitingService {
@@ -22,6 +27,8 @@ export class WaitingService {
     private readonly waitingStore: WaitingStore,
     private readonly prisma: PrismaService,
     private readonly chatService: ChatService,
+    private readonly gameStateStore: GameStateStore,
+    private readonly eventEmitter: EventEmitter2,
     @Inject('IRoomReader') private readonly roomReader: IRoomReader,
     @Inject('IRoomWriter') private readonly roomWriter: IRoomWriter,
   ) {}
@@ -46,13 +53,20 @@ export class WaitingService {
     roomId: number,
     userId: number,
     password?: string,
-  ): Promise<WaitingStateResponseDto> {
+  ): Promise<{
+    state: WaitingStateResponseDto;
+    systemMessage: ChatMessageDto;
+  }> {
     const waiting = await this.loadWaitingEntity(roomId);
 
     waiting.canJoin(userId);
 
     if (waiting.hasPlayer(userId)) {
-      return this.getState(roomId);
+      const state = await this.getState(roomId);
+      const systemMessage = this.chatService.createSystemMessage({
+        message: `${waiting.players.find((p) => p.userId === userId)?.nickname}님이 입장했습니다.`,
+      });
+      return { state, systemMessage };
     }
 
     if (waiting.requiresPassword()) {
@@ -64,7 +78,12 @@ export class WaitingService {
 
     await this.waitingStore.joinRoom(roomId, player, isHost);
 
-    return this.getState(roomId);
+    const state = await this.getState(roomId);
+    const systemMessage = this.chatService.createSystemMessage({
+      message: `${player.nickname}님이 입장했습니다.`,
+    });
+
+    return { state, systemMessage };
   }
 
   private async validatePassword(room: Room, password?: string): Promise<void> {
@@ -144,7 +163,10 @@ export class WaitingService {
       isPrivate?: boolean;
       password?: string;
     },
-  ): Promise<void> {
+  ): Promise<{
+    state: WaitingStateResponseDto;
+    systemMessage: ChatMessageDto;
+  }> {
     const waiting = await this.loadWaitingEntity(roomId);
     waiting.validateSettingsUpdate(requesterId);
 
@@ -157,6 +179,13 @@ export class WaitingService {
     }
 
     await this.roomWriter.updateRoomWhileWaiting(roomId, settings);
+
+    const state = await this.getState(roomId);
+    const systemMessage = this.chatService.createSystemMessage({
+      message: '게임 설정이 변경되었습니다.',
+    });
+
+    return { state, systemMessage };
   }
 
   private async resetTeamsForMode(
@@ -179,10 +208,32 @@ export class WaitingService {
     );
   }
 
-  async kickPlayer(roomId: number, requesterId: number, targetUserId: number): Promise<void> {
+  async kickPlayer(
+    roomId: number,
+    requesterId: number,
+    targetUserId: number,
+  ): Promise<{
+    remainingPlayers: WaitingPlayerState[];
+    systemMessage: ChatMessageDto;
+  }> {
     const waiting = await this.loadWaitingEntity(roomId);
     waiting.validateKick(requesterId, targetUserId);
+
+    const players = await this.waitingStore.getPlayers(roomId);
+    const kickedPlayer = players.find((p) => p.userId === targetUserId);
+
+    if (!kickedPlayer) {
+      throw new NotFoundException({ code: WAITING_ERROR_CODES.PLAYER_NOT_FOUND });
+    }
+
     await this.waitingStore.leaveRoom(roomId, targetUserId);
+
+    const remainingPlayers = await this.waitingStore.getPlayers(roomId);
+    const systemMessage = this.chatService.createSystemMessage({
+      message: `${kickedPlayer.nickname}님이 강퇴되었습니다.`,
+    });
+
+    return { remainingPlayers, systemMessage };
   }
 
   async leaveRoom(roomId: number, userId: number): Promise<void> {
@@ -215,6 +266,49 @@ export class WaitingService {
 
   async markRoomAsStarted(roomId: number): Promise<void> {
     await this.waitingStore.setRoomExpiry(roomId, WAITING_CONSTANTS.GAME_SESSION_TTL_SECONDS);
+  }
+
+  async initializeGameState(roomId: number): Promise<{
+    phase: GamePhase;
+    endsAt: number;
+    phaseContext: null;
+  }> {
+    const loadingEndTime = Date.now() + WAITING_CONSTANTS.LOADING_PHASE_DURATION_MS;
+
+    await this.gameStateStore.set(roomId, {
+      phase: GamePhase.LOADING,
+      endsAt: loadingEndTime,
+      currentRound: 1,
+      totalRounds: WAITING_CONSTANTS.DEFAULT_ROUNDS,
+      currentTheme: null,
+      recentThemes: [],
+      phaseContext: null,
+    });
+
+    this.eventEmitter.emit(GAME_EVENTS.LOADING_STARTED, { roomId });
+
+    return {
+      phase: GamePhase.LOADING,
+      endsAt: loadingEndTime,
+      phaseContext: null,
+    };
+  }
+
+  async handleGameStart(
+    roomId: number,
+    requesterId: number,
+  ): Promise<{
+    gameState: {
+      phase: GamePhase;
+      endsAt: number;
+      phaseContext: null;
+    };
+  }> {
+    await this.startGame(roomId, requesterId);
+    await this.markRoomAsStarted(roomId);
+    const gameState = await this.initializeGameState(roomId);
+
+    return { gameState };
   }
 
   async getState(roomId: number): Promise<WaitingStateResponseDto> {
@@ -258,32 +352,13 @@ export class WaitingService {
     }
   }
 
-  async handleGameStart(
-    roomId: number,
-    userId: number,
-  ): Promise<{
-    roomId: number;
-    players: WaitingPlayerState[];
-  }> {
-    await this.startGame(roomId, userId);
-
-    await this.markRoomAsStarted(roomId);
-
-    const players = await this.getPlayers(roomId);
-
-    return {
-      roomId,
-      players,
-    };
-  }
-
   async handleDisconnect(
     roomId: number,
     userId: number,
   ): Promise<{
     wasLastPlayer: boolean;
     remainingPlayers: WaitingPlayerState[];
-    systemMessage: ReturnType<ChatService['createSystemMessage']> | null;
+    systemMessage: ChatMessageDto | null;
     isGameInProgress: boolean;
   }> {
     const room = await this.findRoomOrThrow(roomId);
@@ -324,7 +399,7 @@ export class WaitingService {
   ): Promise<{
     wasLastPlayer: boolean;
     remainingPlayers: WaitingPlayerState[];
-    systemMessage: ReturnType<ChatService['createSystemMessage']> | null;
+    systemMessage: ChatMessageDto | null;
     isGameInProgress: boolean;
   }> {
     const room = await this.findRoomOrThrow(roomId);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #86

## 📝 작업 내용

- #73 리팩토링 이후 build 이슈로 인해 정리되지 못한 Gateway 계층의 비즈니스 로직을 Service 계층으로 이동하여 각 계층의 책임을 명확히 하려고 합니다.