### PR TITLE
PlayerResponseDto로 도메인 경계 분리

### DIFF
--- a/src/waiting/waiting.gateway.ts
+++ b/src/waiting/waiting.gateway.ts
@@ -22,6 +22,7 @@ import { UpdateOutfitDto } from './dtos/requests/update-outfit.dto';
 import { UpdateSettingsDto } from './dtos/requests/update-settings.dto';
 import { KickUserDto } from './dtos/requests/kick-user.dto';
 import { NudgeUserDto } from './dtos/requests/nudge-user.dto';
+import { PlayerResponseDto } from './dtos/responses/player-response.dto';
 
 interface JwtPayload {
   sub: string;
@@ -101,20 +102,20 @@ export class WaitingGateway implements OnGatewayConnection, OnGatewayDisconnect 
   }
 
   async handleDisconnect(client: Socket) {
-    const data = client.data as ClientData;
+    const clientData = this.getClientData(client);
 
-    if (!data?.userId || !data?.roomId) {
+    if (!clientData?.roomId) {
       return;
     }
 
-    const result = await this.waitingService.handleDisconnect(data.roomId, data.userId);
+    const result = await this.waitingService.handleDisconnect(clientData.roomId, clientData.userId);
 
     if (!result.wasLastPlayer && !result.isGameInProgress) {
-      this.emitPlayerListSync(data.roomId, result.remainingPlayers);
+      this.emitPlayerListSync(clientData.roomId, result.remainingPlayers);
 
       if (result.systemMessage) {
         this.server
-          .to(`room:${data.roomId}`)
+          .to(`room:${clientData.roomId}`)
           .emit(WAITING_EVENTS.ROOM_SYSTEM_MESSAGE, result.systemMessage);
       }
     }
@@ -135,7 +136,7 @@ export class WaitingGateway implements OnGatewayConnection, OnGatewayDisconnect 
     return null;
   }
 
-  private emitPlayerListSync(roomId: number, players: unknown[]) {
+  private emitPlayerListSync(roomId: number, players: PlayerResponseDto[]) {
     this.server.to(`room:${roomId}`).emit(WAITING_EVENTS.ROOM_SYNC_PLAYER_LIST, {
       players,
     });
@@ -150,14 +151,15 @@ export class WaitingGateway implements OnGatewayConnection, OnGatewayDisconnect 
 
     if (clientData.roomId && clientData.roomId !== body.roomId) {
       const previousRoomId = clientData.roomId;
-      const playersBeforeLeave = await this.waitingService.getPlayers(previousRoomId);
 
-      await this.waitingService.leaveRoom(previousRoomId, clientData.userId);
+      const remainingPlayers = await this.waitingService.leaveRoom(
+        previousRoomId,
+        clientData.userId,
+      );
       await client.leave(`room:${previousRoomId}`);
 
-      if (playersBeforeLeave.length > 1) {
-        const players = await this.waitingService.getPlayers(previousRoomId);
-        this.emitPlayerListSync(previousRoomId, players);
+      if (remainingPlayers.length > 0) {
+        this.emitPlayerListSync(previousRoomId, remainingPlayers);
       }
     }
 
@@ -171,7 +173,6 @@ export class WaitingGateway implements OnGatewayConnection, OnGatewayDisconnect 
     await client.join(`room:${body.roomId}`);
 
     this.emitPlayerListSync(body.roomId, state.players);
-
     this.server.to(`room:${body.roomId}`).emit(WAITING_EVENTS.ROOM_SYSTEM_MESSAGE, systemMessage);
 
     client.emit(WAITING_EVENTS.ROOM_JOIN_SUCCESS, state);
@@ -317,7 +318,7 @@ export class WaitingGateway implements OnGatewayConnection, OnGatewayDisconnect 
 
     const { roomId, userId } = clientData;
 
-    const players = await this.waitingService.getPlayers(roomId);
+    const players = await this.waitingService.getPlayersDto(roomId);
     const targetPlayer = players.find((p) => p.userId === body.targetUserId);
     if (!targetPlayer) {
       throw wsError(404, WAITING_ERROR_CODES.PLAYER_NOT_FOUND);

--- a/src/waiting/waiting.service.ts
+++ b/src/waiting/waiting.service.ts
@@ -3,6 +3,7 @@ import { Team, RoomMode, RoomStatus } from '@prisma/client';
 import { WaitingStore, WaitingPlayerState } from './waiting.store';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { WaitingStateResponseDto } from './dtos/responses/waiting-state-response.dto';
+import { PlayerResponseDto } from './dtos/responses/player-response.dto';
 import { PlayerPageStatus } from './dtos/requests/update-status.dto';
 import { PasswordEncoderUtil } from 'src/common/utils/password-encoder.util';
 import { Waiting } from './entities/waiting.entity';
@@ -47,6 +48,26 @@ export class WaitingService {
     } catch {
       throw new NotFoundException({ code: WAITING_ERROR_CODES.ROOM_NOT_FOUND });
     }
+  }
+
+  private convertToDto(players: WaitingPlayerState[]): PlayerResponseDto[] {
+    return players.map(
+      (p) =>
+        new PlayerResponseDto({
+          userId: p.userId,
+          nickname: p.nickname,
+          team: p.team,
+          isReady: p.isReady,
+          level: p.level,
+          status: p.pageStatus,
+          outfit: p.outfit,
+        }),
+    );
+  }
+
+  async getPlayersDto(roomId: number): Promise<PlayerResponseDto[]> {
+    const players = await this.waitingStore.getPlayers(roomId);
+    return this.convertToDto(players);
   }
 
   async joinRoom(
@@ -213,7 +234,7 @@ export class WaitingService {
     requesterId: number,
     targetUserId: number,
   ): Promise<{
-    remainingPlayers: WaitingPlayerState[];
+    remainingPlayers: PlayerResponseDto[];
     systemMessage: ChatMessageDto;
   }> {
     const waiting = await this.loadWaitingEntity(roomId);
@@ -233,17 +254,22 @@ export class WaitingService {
       message: `${kickedPlayer.nickname}님이 강퇴되었습니다.`,
     });
 
-    return { remainingPlayers, systemMessage };
+    return {
+      remainingPlayers: this.convertToDto(remainingPlayers),
+      systemMessage,
+    };
   }
 
-  async leaveRoom(roomId: number, userId: number): Promise<void> {
+  async leaveRoom(roomId: number, userId: number): Promise<PlayerResponseDto[]> {
     await this.waitingStore.leaveRoom(roomId, userId);
-
     const players = await this.waitingStore.getPlayers(roomId);
+
     if (!players.length) {
       await this.waitingStore.clearRoom(roomId);
       await this.roomWriter.removeRoom(roomId);
     }
+
+    return this.convertToDto(players);
   }
 
   async startGame(roomId: number, requesterId: number): Promise<void> {
@@ -325,21 +351,8 @@ export class WaitingService {
         maxPlayers: room.maxPlayers,
         isPrivate: room.isPrivate,
       },
-      players: players.map((p) => ({
-        userId: p.userId,
-        nickname: p.nickname,
-        team: p.team,
-        isReady: p.isReady,
-        level: p.level,
-        status: p.pageStatus,
-        outfit: p.outfit,
-      })),
+      players: this.convertToDto(players),
     });
-  }
-
-  async getPlayers(roomId: number) {
-    await this.findRoomOrThrow(roomId);
-    return this.waitingStore.getPlayers(roomId);
   }
 
   async canStartMatch(roomId: number): Promise<boolean> {
@@ -357,14 +370,14 @@ export class WaitingService {
     userId: number,
   ): Promise<{
     wasLastPlayer: boolean;
-    remainingPlayers: WaitingPlayerState[];
+    remainingPlayers: PlayerResponseDto[];
     systemMessage: ChatMessageDto | null;
     isGameInProgress: boolean;
   }> {
     const room = await this.findRoomOrThrow(roomId);
     const isGameInProgress = room.status !== RoomStatus.WAITING;
 
-    const players = await this.getPlayers(roomId);
+    const players = await this.waitingStore.getPlayers(roomId);
     const wasLastPlayer = players.length === 1;
     const leavingPlayer = players.find((p) => p.userId === userId);
 
@@ -376,7 +389,10 @@ export class WaitingService {
       }
     }
 
-    const remainingPlayers = wasLastPlayer || isGameInProgress ? [] : await this.getPlayers(roomId);
+    const remainingPlayers =
+      wasLastPlayer || isGameInProgress
+        ? []
+        : this.convertToDto(await this.waitingStore.getPlayers(roomId));
 
     const systemMessage =
       !wasLastPlayer && !isGameInProgress && leavingPlayer
@@ -398,20 +414,22 @@ export class WaitingService {
     userId: number,
   ): Promise<{
     wasLastPlayer: boolean;
-    remainingPlayers: WaitingPlayerState[];
+    remainingPlayers: PlayerResponseDto[];
     systemMessage: ChatMessageDto | null;
     isGameInProgress: boolean;
   }> {
     const room = await this.findRoomOrThrow(roomId);
     const isGameInProgress = room.status !== RoomStatus.WAITING;
 
-    const players = await this.getPlayers(roomId);
+    const players = await this.waitingStore.getPlayers(roomId);
     const wasLastPlayer = players.length === 1;
     const leavingPlayer = players.find((p) => p.userId === userId);
 
     await this.leaveRoom(roomId, userId);
 
-    const remainingPlayers = wasLastPlayer ? [] : await this.getPlayers(roomId);
+    const remainingPlayers = wasLastPlayer
+      ? []
+      : this.convertToDto(await this.waitingStore.getPlayers(roomId));
 
     const systemMessage =
       !wasLastPlayer && !isGameInProgress && leavingPlayer
@@ -429,7 +447,7 @@ export class WaitingService {
   }
 
   async handleChatMessage(roomId: number, userId: number, messageText: string) {
-    const players = await this.getPlayers(roomId);
+    const players = await this.waitingStore.getPlayers(roomId);
     const player = players.find((p) => p.userId === userId);
 
     if (!player) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #88

## 📝 작업 내용

- Waiting 도메인에서 관리하는 플레이어 내부 상태를 Gateway / Client로 직접 노출하지 않도록 구조를 개선했습니다.
- 대기실 플레이어 응답을 PlayerResponseDto 기반으로 통일하여 외부와의 응답 계약을 명확히 했습니다.
- Gateway 이벤트 payload 타입을 DTO 기준으로 정리하여 도메인 의존성을 제거했습니다.
- WaitingService의 public 메서드에서 Store 모델 반환을 제거하고, 응답 전용 DTO만 반환하도록 리팩토링했습니다.