### PR TITLE
대기실 플레이어 outfit 기본값 적용

### DIFF
--- a/src/waiting/dtos/responses/player-response.dto.ts
+++ b/src/waiting/dtos/responses/player-response.dto.ts
@@ -47,6 +47,6 @@ export class PlayerResponseDto {
     this.isReady = data.isReady;
     this.level = data.level;
     this.status = data.status || PlayerPageStatus.IDLE;
-    this.outfit = data.outfit;
+    this.outfit = data.outfit ?? { bird: 'bird_01' };
   }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #93

## 📝 작업 내용

- 대기실 플레이어 outfit 기본값을 적용해서 프론트에서 기본 이미지(bird_01)가 정상적으로 렌더링되도록 수정했습니다.
원래 마이페이지에서 설정하도록 되어 있었지만, 기본값을 적용하여 대기실에서도 문제없이 표시되도록 개선했습니다.