### PR TITLE
전역 채팅에서 내가 차단한 사용자의 메시지 숨김 기능 구현

### DIFF
--- a/src/block/block.repository.ts
+++ b/src/block/block.repository.ts
@@ -38,7 +38,7 @@ export class BlockRepository implements IBlockRepository {
     });
   }
 
-  async findBlockedUsersByBlockers(
+  async findBlockedUsersByBlockerIds(
     blockerIds: number[],
   ): Promise<{ blockerId: number; blockedId: number }[]> {
     return this.prisma.blockList.findMany({

--- a/src/block/block.repository.ts
+++ b/src/block/block.repository.ts
@@ -38,6 +38,20 @@ export class BlockRepository implements IBlockRepository {
     });
   }
 
+  async findBlockedUsersByBlockers(
+    blockerIds: number[],
+  ): Promise<{ blockerId: number; blockedId: number }[]> {
+    return this.prisma.blockList.findMany({
+      where: {
+        blockerId: { in: blockerIds },
+      },
+      select: {
+        blockerId: true,
+        blockedId: true,
+      },
+    });
+  }
+
   async findBlockersByBlocked(blockedId: number): Promise<{ blockerId: number }[]> {
     return this.prisma.blockList.findMany({
       where: {

--- a/src/block/block.service.ts
+++ b/src/block/block.service.ts
@@ -25,10 +25,10 @@ export class BlockService {
     return this.blockRepository.findBlockersByBlocked(userId);
   }
 
-  async getBlockedUsersForMany(
+  async getBlockedUsersByUserIds(
     userIds: number[],
   ): Promise<{ blockerId: number; blockedId: number }[]> {
-    return this.blockRepository.findBlockedUsersByBlockers(userIds);
+    return this.blockRepository.findBlockedUsersByBlockerIds(userIds);
   }
 
   async block(userId: number, targetUserId: number): Promise<Block> {

--- a/src/block/block.service.ts
+++ b/src/block/block.service.ts
@@ -25,6 +25,12 @@ export class BlockService {
     return this.blockRepository.findBlockersByBlocked(userId);
   }
 
+  async getBlockedUsersForMany(
+    userIds: number[],
+  ): Promise<{ blockerId: number; blockedId: number }[]> {
+    return this.blockRepository.findBlockedUsersByBlockers(userIds);
+  }
+
   async block(userId: number, targetUserId: number): Promise<Block> {
     const targetUser = await this.userService.findOneById(targetUserId);
     if (!targetUser) {

--- a/src/block/interfaces/block-repository.interface.ts
+++ b/src/block/interfaces/block-repository.interface.ts
@@ -3,6 +3,9 @@ import { Block } from '../block.entity';
 export interface IBlockRepository {
   findBlockRelation(blockerId: number, blockedId: number): Promise<Block | null>;
   findBlockedUsersByBlocker(blockerId: number): Promise<{ blockedId: number }[]>;
+  findBlockedUsersByBlockers(
+    blockerIds: number[],
+  ): Promise<{ blockerId: number; blockedId: number }[]>;
   findBlockersByBlocked(blockedId: number): Promise<{ blockerId: number }[]>;
   createBlockRelation(blockerId: number, blockedId: number): Promise<Block>;
   deleteBlockRelation(blockerId: number, blockedId: number): Promise<void>;

--- a/src/block/interfaces/block-repository.interface.ts
+++ b/src/block/interfaces/block-repository.interface.ts
@@ -3,7 +3,7 @@ import { Block } from '../block.entity';
 export interface IBlockRepository {
   findBlockRelation(blockerId: number, blockedId: number): Promise<Block | null>;
   findBlockedUsersByBlocker(blockerId: number): Promise<{ blockedId: number }[]>;
-  findBlockedUsersByBlockers(
+  findBlockedUsersByBlockerIds(
     blockerIds: number[],
   ): Promise<{ blockerId: number; blockedId: number }[]>;
   findBlockersByBlocked(blockedId: number): Promise<{ blockerId: number }[]>;

--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -15,6 +15,7 @@ import { ChatSendChannel, SendMessageDto } from './dtos/requests/send-message.dt
 import { CHAT_ERROR_CODES, CHAT_EVENTS } from './constants/chat.constant';
 import { SocketExceptionFilter } from 'src/common/filters/socket-exception.filter';
 import { wsError } from 'src/common/utils/ws-error.util';
+import { BlockService } from 'src/block/block.service';
 
 interface JwtPayload {
   sub: string;
@@ -57,6 +58,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   constructor(
     private readonly chatService: ChatService,
     private readonly jwtService: JwtService,
+    private readonly blockService: BlockService,
   ) {}
 
   private getClientData(client: Socket): ClientData | null {
@@ -65,7 +67,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
       : null;
   }
 
-  handleConnection(client: Socket) {
+  async handleConnection(client: Socket) {
     const auth = client.handshake.auth ?? {};
     const headers = client.handshake.headers;
 
@@ -83,7 +85,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     try {
       const payload = this.jwtService.verify<JwtPayload>(token);
       client.data = { userId: Number(payload.sub), nickname: payload.nickname };
-      void client.join('lobby');
+      await client.join('lobby');
     } catch (err: unknown) {
       const isTokenExpired = err instanceof Error && err.name === 'TokenExpiredError';
       const error = wsError(
@@ -106,7 +108,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
     try {
       if (dto.channel === ChatSendChannel.GLOBAL) {
-        this.handleGlobalMessage(clientData, dto);
+        await this.handleGlobalMessage(clientData, dto);
       } else if (dto.channel === ChatSendChannel.DIRECT) {
         await this.handleDirectMessage(clientData, dto, client);
       }
@@ -116,14 +118,32 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     }
   }
 
-  private handleGlobalMessage(clientData: ClientData, dto: SendMessageDto): void {
+  private async handleGlobalMessage(clientData: ClientData, dto: SendMessageDto) {
     const message = this.chatService.handleGlobalMessage({
       senderId: clientData.userId.toString(),
       senderNickname: clientData.nickname,
       message: dto.message,
     });
 
-    this.server.to('lobby').emit(CHAT_EVENTS.LOBBY_MESSAGE, message);
+    const sockets = await this.server.in('lobby').fetchSockets();
+    const userIds = sockets.map((s) => (s.data as ClientData)?.userId).filter(Boolean);
+    const allBlocked = await this.blockService.getBlockedUsersForMany(userIds);
+
+    const blockedMap = new Map<number, Set<number>>();
+    for (const { blockerId, blockedId } of allBlocked) {
+      if (!blockedMap.has(blockerId)) blockedMap.set(blockerId, new Set());
+      blockedMap.get(blockerId)!.add(blockedId);
+    }
+
+    for (const socket of sockets) {
+      const data = socket.data as ClientData;
+      if (!data) continue;
+
+      const blockedSet = blockedMap.get(data.userId) ?? new Set();
+      if (blockedSet.has(clientData.userId)) continue;
+
+      socket.emit(CHAT_EVENTS.LOBBY_MESSAGE, message);
+    }
   }
 
   private async handleDirectMessage(
@@ -148,6 +168,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     senderClient.emit(CHAT_EVENTS.LOBBY_MESSAGE, message);
     this.server.to(targetSocketId).emit(CHAT_EVENTS.LOBBY_MESSAGE, message);
   }
+
   private async findSocketIdByUserId(userId: number): Promise<string | null> {
     const sockets = await this.server.in('lobby').fetchSockets();
     const targetSocket = sockets.find((s) => (s.data as ClientData).userId === userId);

--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -127,7 +127,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
     const sockets = await this.server.in('lobby').fetchSockets();
     const userIds = sockets.map((s) => (s.data as ClientData)?.userId).filter(Boolean);
-    const allBlocked = await this.blockService.getBlockedUsersForMany(userIds);
+    const allBlocked = await this.blockService.getBlockedUsersByUserIds(userIds);
 
     const blockedMap = new Map<number, Set<number>>();
     for (const { blockerId, blockedId } of allBlocked) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #99 

## 📝 작업 내용

- BlockService의 getBlockedUsersForMany를 사용해 각 클라이언트가 차단한 사용자 목록을 가져옴
- ChatGateway.handleGlobalMessage에서 메시지를 브로드캐스트할 때, 각 소켓이 메시지 발신자를 차단했는지 확인하고 차단한 경우 해당 메시지를 송신하지 않음