### PR TITLE
의상 검증 로직 개선

### DIFF
--- a/src/common/utils/flatten-validation-errors.util.ts
+++ b/src/common/utils/flatten-validation-errors.util.ts
@@ -14,7 +14,7 @@ export function flattenValidationErrors(
 
     if (error.constraints) {
       result.push({
-        field: currentPath,
+        field: parentPath ? error.property : currentPath,
         reason: Object.values(error.constraints),
       });
     }

--- a/src/common/utils/flatten-validation-errors.util.ts
+++ b/src/common/utils/flatten-validation-errors.util.ts
@@ -14,7 +14,7 @@ export function flattenValidationErrors(
 
     if (error.constraints) {
       result.push({
-        field: parentPath ? error.property : currentPath,
+        field: error.property,
         reason: Object.values(error.constraints),
       });
     }

--- a/src/outfit/entities/outfit.entity.ts
+++ b/src/outfit/entities/outfit.entity.ts
@@ -2,13 +2,12 @@ import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import { CosmeticSubCategory } from '@prisma/client';
 import { OutfitIds } from '../outfit.type';
 import { OUTFIT_DOMAIN_ERRORS, OUTFIT_ERROR_CODES } from '../constants/outfit.constant';
+import { ErrorDetail } from 'src/common/utils/error-response.util';
 
 type UpdateOutfitProps = Partial<OutfitIds>;
 
 export class Outfit {
-  private constructor(private props: OutfitIds) {
-    this.validate();
-  }
+  private constructor(private props: OutfitIds) {}
 
   static create(props: OutfitIds | undefined | null): Outfit {
     if (!props) {
@@ -68,25 +67,35 @@ export class Outfit {
       Object.entries(props).filter(([, value]) => value !== undefined),
     );
     Object.assign(this.props, updates);
-    this.validate();
   }
 
   validateOwnership(ownedIds: Set<number>): void {
-    const equippedIds = this.getEquippedIds();
+    const notOwnedItems: ErrorDetail[] = [];
 
-    for (const id of equippedIds) {
-      if (!ownedIds.has(id)) {
-        throw new ForbiddenException({
-          code: OUTFIT_ERROR_CODES.ITEM_NOT_OWNED,
-          errors: [OUTFIT_DOMAIN_ERRORS[OUTFIT_ERROR_CODES.ITEM_NOT_OWNED]],
+    for (const key of Object.keys(this.props) as (keyof OutfitIds)[]) {
+      const itemId = this.props[key];
+
+      if (itemId === null || itemId === undefined) {
+        continue;
+      }
+
+      if (!ownedIds.has(itemId)) {
+        notOwnedItems.push({
+          field: key,
+          reason: ['You do not own this item'],
         });
       }
     }
+
+    if (notOwnedItems.length > 0) {
+      throw new ForbiddenException({
+        code: OUTFIT_ERROR_CODES.ITEM_NOT_OWNED,
+        errors: notOwnedItems,
+      });
+    }
   }
 
-  validateCategories(
-    cosmeticItemMap: Map<number, { id: number; subCategory: CosmeticSubCategory }>,
-  ): void {
+  validateCategories(cosmeticItemMap: Map<number, { subCategory: CosmeticSubCategory }>): void {
     const categoryMap: Record<keyof OutfitIds, CosmeticSubCategory> = {
       bird: CosmeticSubCategory.BIRD,
       hat: CosmeticSubCategory.HAT,
@@ -97,43 +106,32 @@ export class Outfit {
       effect: CosmeticSubCategory.EFFECT,
     };
 
+    const validationErrors: ErrorDetail[] = [];
+
     for (const key of Object.keys(this.props) as (keyof OutfitIds)[]) {
       const itemId = this.props[key];
 
-      if (itemId === null || itemId === undefined) continue;
+      if (itemId === null || itemId === undefined) {
+        continue;
+      }
 
       const cosmeticItem = cosmeticItemMap.get(itemId);
       if (!cosmeticItem) {
-        throw new BadRequestException({
-          code: OUTFIT_ERROR_CODES.ITEM_NOT_FOUND,
-          errors: [
-            {
-              field: key,
-              reason: `Item ${itemId} not found`,
-            },
-          ],
-        });
+        continue;
       }
 
       if (categoryMap[key] !== cosmeticItem.subCategory) {
-        throw new BadRequestException({
-          code: OUTFIT_ERROR_CODES.INVALID_CATEGORY_MATCH,
-          errors: [
-            {
-              field: key,
-              reason: `This item is not in the ${key} category`,
-            },
-          ],
+        validationErrors.push({
+          field: key,
+          reason: [`This item is not in the '${key}' category`],
         });
       }
     }
-  }
 
-  private validate(): void {
-    if (!this.props.bird || typeof this.props.bird !== 'number') {
+    if (validationErrors.length > 0) {
       throw new BadRequestException({
-        code: OUTFIT_ERROR_CODES.MISSING_BIRD_FIELD,
-        errors: [OUTFIT_DOMAIN_ERRORS[OUTFIT_ERROR_CODES.MISSING_BIRD_FIELD]],
+        code: OUTFIT_ERROR_CODES.INVALID_CATEGORY_MATCH,
+        errors: validationErrors,
       });
     }
   }

--- a/src/outfit/entities/outfit.entity.ts
+++ b/src/outfit/entities/outfit.entity.ts
@@ -70,22 +70,12 @@ export class Outfit {
   }
 
   validateOwnership(ownedIds: Set<number>): void {
-    const notOwnedItems: ErrorDetail[] = [];
-
-    for (const key of Object.keys(this.props) as (keyof OutfitIds)[]) {
-      const itemId = this.props[key];
-
-      if (itemId === null || itemId === undefined) {
-        continue;
-      }
-
-      if (!ownedIds.has(itemId)) {
-        notOwnedItems.push({
-          field: key,
-          reason: ['You do not own this item'],
-        });
-      }
-    }
+    const notOwnedItems: ErrorDetail[] = Object.entries(this.props)
+      .filter(([, itemId]) => itemId != null && !ownedIds.has(itemId))
+      .map(([key]) => ({
+        field: key,
+        reason: ['You do not own this item'],
+      }));
 
     if (notOwnedItems.length > 0) {
       throw new ForbiddenException({
@@ -106,27 +96,17 @@ export class Outfit {
       effect: CosmeticSubCategory.EFFECT,
     };
 
-    const validationErrors: ErrorDetail[] = [];
+    const validationErrors: ErrorDetail[] = Object.entries(this.props)
+      .filter(([key, itemId]) => {
+        if (itemId == null) return false;
 
-    for (const key of Object.keys(this.props) as (keyof OutfitIds)[]) {
-      const itemId = this.props[key];
-
-      if (itemId === null || itemId === undefined) {
-        continue;
-      }
-
-      const cosmeticItem = cosmeticItemMap.get(itemId);
-      if (!cosmeticItem) {
-        continue;
-      }
-
-      if (categoryMap[key] !== cosmeticItem.subCategory) {
-        validationErrors.push({
-          field: key,
-          reason: [`This item is not in the '${key}' category`],
-        });
-      }
-    }
+        const cosmeticItem = cosmeticItemMap.get(itemId);
+        return cosmeticItem != null && categoryMap[key] !== cosmeticItem.subCategory;
+      })
+      .map(([key]) => ({
+        field: key,
+        reason: [`This item is not in the ${key} category`],
+      }));
 
     if (validationErrors.length > 0) {
       throw new BadRequestException({

--- a/src/wardrobe/constants/wardrobe.constant.ts
+++ b/src/wardrobe/constants/wardrobe.constant.ts
@@ -1,15 +1,3 @@
 export const WARDROBE_ERROR_CODES = {
-  MISSING_OUTFIT_FIELD: 'MISSING_OUTFIT_FIELD',
-  MISSING_BIRD_FIELD: 'MISSING_BIRD_FIELD',
+  ITEM_NOT_FOUND: 'ITEM_NOT_FOUND',
 } as const;
-
-export const WARDROBE_DOMAIN_ERRORS: Record<string, { field: string; reason: string }> = {
-  MISSING_OUTFIT_FIELD: {
-    field: 'outfit',
-    reason: 'Outfit data is required',
-  },
-  MISSING_BIRD_FIELD: {
-    field: 'bird',
-    reason: 'Bird is required',
-  },
-};

--- a/src/wardrobe/wardrobe.service.ts
+++ b/src/wardrobe/wardrobe.service.ts
@@ -1,12 +1,12 @@
-import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import type { IWardrobeRepository } from './interfaces/wardrobe-repository.interface';
 import { UpdateOutfitRequestDto } from './dtos/requests/update-outfit.request.dto';
 import { WardrobeCosmeticInventoryResponseDto } from './dtos/responses/wardrobe-cosmetic-inventory.response.dto';
 import { WardrobeConsumableInventoryResponseDto } from './dtos/responses/wardrobe-consumable-inventory.response.dto';
-import { WARDROBE_ERROR_CODES } from './constants/wardrobe.constant';
 import { Outfit } from 'src/outfit/entities/outfit.entity';
 import { OutfitIds } from 'src/outfit/outfit.type';
 import { OutfitIdsResponseDto } from 'src/outfit/dtos/responses/outfit-ids-response.dto';
+import { WARDROBE_ERROR_CODES } from './constants/wardrobe.constant';
 
 @Injectable()
 export class WardrobeService {
@@ -37,47 +37,39 @@ export class WardrobeService {
     userId: number,
     request: UpdateOutfitRequestDto,
   ): Promise<OutfitIdsResponseDto> {
-    if (!request.outfitIds) {
-      throw new BadRequestException({
-        code: WARDROBE_ERROR_CODES.MISSING_OUTFIT_FIELD,
-      });
-    }
-    const bird = request.outfitIds.bird;
-    if (bird === null || bird === undefined) {
-      throw new BadRequestException({
-        code: WARDROBE_ERROR_CODES.MISSING_BIRD_FIELD,
-      });
-    }
-
-    const outfitIds: OutfitIds = {
-      bird,
-      hat: request.outfitIds.hat ?? null,
-      accessory: request.outfitIds.accessory ?? null,
-      top: request.outfitIds.top ?? null,
-      bottom: request.outfitIds.bottom ?? null,
-      shoes: request.outfitIds.shoes ?? null,
-      effect: request.outfitIds.effect ?? null,
-    };
-
+    const outfitIds: OutfitIds = request.outfitIds;
     const outfit = Outfit.create(outfitIds);
 
-    const ownedCosmeticIds = await this.wardrobeRepository.findOwnedCosmeticIds(userId);
-    const ownedCosmeticIdsSet = new Set(ownedCosmeticIds);
-    outfit.validateOwnership(ownedCosmeticIdsSet);
-
-    const itemIds = Object.values(outfitIds).filter(
-      (id): id is number => id !== null && id !== undefined,
-    );
-
-    const cosmeticItems = await this.wardrobeRepository.findCosmeticItemsByIds(new Set(itemIds));
-    const cosmeticItemMap = new Map(
-      cosmeticItems.map((item) => [item.id, { id: item.id, subCategory: item.subCategory }]),
-    );
-
-    outfit.validateCategories(cosmeticItemMap);
-
+    await this.validateOwnership(outfit, userId);
+    await this.validateCategories(outfit);
     await this.wardrobeRepository.updateUserOutfit(userId, outfit.getAll());
 
     return new OutfitIdsResponseDto(outfit.getAll());
+  }
+
+  private async validateOwnership(outfit: Outfit, userId: number): Promise<void> {
+    const ownedCosmeticIds = await this.wardrobeRepository.findOwnedCosmeticIds(userId);
+    const ownedCosmeticIdsSet = new Set(ownedCosmeticIds);
+    outfit.validateOwnership(ownedCosmeticIdsSet);
+  }
+
+  private async validateCategories(outfit: Outfit): Promise<void> {
+    const equippedItemIds = outfit.getEquippedIds();
+
+    if (equippedItemIds.size === 0) {
+      return;
+    }
+
+    const cosmeticItems = await this.wardrobeRepository.findCosmeticItemsByIds(equippedItemIds);
+
+    if (cosmeticItems.length !== equippedItemIds.size) {
+      throw new NotFoundException({ code: WARDROBE_ERROR_CODES.ITEM_NOT_FOUND });
+    }
+
+    const cosmeticItemMap = new Map(
+      cosmeticItems.map((item) => [item.id, { subCategory: item.subCategory }]),
+    );
+
+    outfit.validateCategories(cosmeticItemMap);
   }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #127

## 📝 작업 내용

### 1. 검증 계층 분리
- DTO Layer (400): 입력값 형식 검증
- Service Layer (404): 리소스 존재성 검증
- Entity Layer (400 / 403): 비즈니스 규칙 검증

### 2. bird 필드 필수 처리
- DTO에서 400 Bad Request로 처리

### 3. 중복 검증 제거
- Entity에서 불필요한 검증 로직 정리

### 4. 필드명 간소화
- "outfitIds.bird" → "bird"