### PR TITLE
친구 추천 로직을 Service 계층으로 이동

### DIFF
--- a/src/friend/friend.repository.ts
+++ b/src/friend/friend.repository.ts
@@ -3,7 +3,7 @@ import { FriendshipData, UserProfile } from './types/friend.type';
 import { IFriendRepository } from './interfaces/friend-repository.interface';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { Injectable } from '@nestjs/common';
-import { FriendSearchType, FRIEND_SEARCH_RULES } from './constants/friend.constant';
+import { FriendSearchType } from './constants/friend.constant';
 import { paginate } from 'src/common/utils/paginate.util';
 import { UserWithProfile } from 'src/user/types/user-with-profile.type';
 
@@ -137,32 +137,26 @@ export class FriendRepository implements IFriendRepository {
     return paginate(userProfiles, limit);
   }
 
-  async getRandomUsersForRecommendation(
-    userId: number,
+  async getRecommendationCandidates(
     excludeIds: number[],
+    limit: number,
+    offset: number,
   ): Promise<UserProfile[]> {
-    const allExcludeIds = [userId, ...excludeIds];
-    const count = await this.prisma.user.count({
-      where: { id: { notIn: allExcludeIds } },
-    });
-
-    if (count === 0) {
-      return [];
-    }
-
-    const takeLimit = Math.min(count, FRIEND_SEARCH_RULES.RECOMMENDED_FRIENDS_LIMIT);
-    const maxOffset = Math.max(0, count - takeLimit);
-    const randomOffset = count > takeLimit ? Math.floor(Math.random() * maxOffset) : 0;
-
     const users = await this.prisma.user.findMany({
-      where: { id: { notIn: allExcludeIds } },
+      where: { id: { notIn: excludeIds } },
       include: { profile: true },
-      skip: randomOffset,
-      take: takeLimit,
+      skip: offset,
+      take: limit,
       orderBy: { id: 'asc' },
     });
 
     return this.mapToUserProfiles(users);
+  }
+
+  async countRecommendationCandidates(excludeIds: number[]): Promise<number> {
+    return this.prisma.user.count({
+      where: { id: { notIn: excludeIds } },
+    });
   }
 
   async deleteFriendshipIfExists(userId: number, targetUserId: number): Promise<void> {

--- a/src/friend/friend.service.ts
+++ b/src/friend/friend.service.ts
@@ -137,11 +137,7 @@ export class FriendService {
       return;
     }
 
-    const result = await this.friendRepository.updateFriendshipStatus(
-      request.id,
-      FriendStatus.ACCEPTED,
-    );
-    return result;
+    return this.friendRepository.updateFriendshipStatus(request.id, FriendStatus.ACCEPTED);
   }
 
   async removeFriend(userId: number, friendUserId: number): Promise<void> {
@@ -218,8 +214,22 @@ export class FriendService {
 
   async getRecommendedFriends(userId: number): Promise<SearchFriendResponseDto[]> {
     const excludeIds = await this.getExcludedUserIds(userId, false);
+    const allExcludeIds = [userId, ...excludeIds];
+    const count = await this.friendRepository.countRecommendationCandidates(allExcludeIds);
 
-    const users = await this.friendRepository.getRandomUsersForRecommendation(userId, excludeIds);
+    if (count === 0) {
+      return [];
+    }
+
+    const limit = Math.min(count, FRIEND_SEARCH_RULES.RECOMMENDED_FRIENDS_LIMIT);
+    const maxOffset = Math.max(0, count - limit);
+    const offset = count > limit ? Math.floor(Math.random() * maxOffset) : 0;
+
+    const users = await this.friendRepository.getRecommendationCandidates(
+      allExcludeIds,
+      limit,
+      offset,
+    );
 
     if (!users.length) {
       return [];
@@ -287,11 +297,7 @@ export class FriendService {
     ]);
 
     const blockedIds = blockedUsers.map((b) => b.blockedId);
-    const excludeIds = includeUserId
-      ? [userId, ...relatedIds, ...blockedIds]
-      : [...relatedIds, ...blockedIds];
-
-    return excludeIds;
+    return includeUserId ? [userId, ...relatedIds, ...blockedIds] : [...relatedIds, ...blockedIds];
   }
 
   private validateSelfRequest(userId: number, targetUserId: number): void {

--- a/src/friend/interfaces/friend-repository.interface.ts
+++ b/src/friend/interfaces/friend-repository.interface.ts
@@ -22,5 +22,10 @@ export interface IFriendRepository {
     limit: number,
     cursor?: number,
   ): Promise<{ data: UserProfile[]; hasNextPage: boolean; nextCursor: number | null }>;
-  getRandomUsersForRecommendation(userId: number, excludeIds: number[]): Promise<UserProfile[]>;
+  countRecommendationCandidates(excludeIds: number[]): Promise<number>;
+  getRecommendationCandidates(
+    excludeIds: number[],
+    limit: number,
+    offset: number,
+  ): Promise<UserProfile[]>;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #135

## 📝 작업 내용

- 책임 분리를 위해 기존 Repository에 있던 추천 대상 count 조회, limit 계산, 랜덤 offset 계산 로직을 Service 계층으로 이동했습니다.