### PR TITLE
게임하기(최종 결산) 구현

### DIFF
--- a/prisma/migrations/20260223054752_add_match_rewards_and_details/migration.sql
+++ b/prisma/migrations/20260223054752_add_match_rewards_and_details/migration.sql
@@ -1,0 +1,27 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `result` on the `match_results` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "public"."match_results_result_idx";
+
+-- AlterTable
+ALTER TABLE "public"."match_results" DROP COLUMN "result",
+ADD COLUMN     "awarded_coin" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "awarded_xp" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "outcome" "public"."Result",
+ADD COLUMN     "placement" INTEGER,
+ADD COLUMN     "rewarded_at" TIMESTAMP(3),
+ADD COLUMN     "score" INTEGER,
+ADD COLUMN     "team" "public"."Team" NOT NULL DEFAULT 'NONE';
+
+-- CreateIndex
+CREATE INDEX "game_items_level_idx" ON "public"."game_items"("level");
+
+-- CreateIndex
+CREATE INDEX "match_results_outcome_idx" ON "public"."match_results"("outcome");
+
+-- CreateIndex
+CREATE INDEX "match_results_match_id_idx" ON "public"."match_results"("match_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -213,23 +213,23 @@ model Match {
 }
 
 model MatchResult {
-  id           Int       @id @default(autoincrement())
-  matchId      Int       @map("match_id")
-  roomMemberId Int       @map("room_member_id")
+  id           Int         @id @default(autoincrement())
+  matchId      Int         @map("match_id")
+  roomMemberId Int         @map("room_member_id")
 
   score        Int?
   placement    Int?
-  team         Team      @default(NONE)
+  team         Team        @default(NONE)
   outcome      Result?
 
-  awardedXp    Int       @default(0) @map("awarded_xp")
-  awardedCoin  Int       @default(0) @map("awarded_coin")
-  rewardedAt   DateTime? @map("rewarded_at")
+  awardedXp    Int         @default(0) @map("awarded_xp")
+  awardedCoin  Int         @default(0) @map("awarded_coin")
+  rewardedAt   DateTime?   @map("rewarded_at")
 
-  recordedAt   DateTime  @default(now()) @map("recorded_at")
+  recordedAt   DateTime    @default(now()) @map("recorded_at")
 
-  roomMember RoomMember  @relation(fields: [roomMemberId], references: [id], onDelete: Restrict)
-  match      Match       @relation(fields: [matchId], references: [id], onDelete: Cascade)
+  roomMember   RoomMember  @relation(fields: [roomMemberId], references: [id], onDelete: Restrict)
+  match        Match       @relation(fields: [matchId], references: [id], onDelete: Cascade)
 
   @@unique([roomMemberId, matchId])
   @@index([outcome])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -213,18 +213,28 @@ model Match {
 }
 
 model MatchResult {
-  id           Int      @id @default(autoincrement())
-  roomMemberId Int      @map("room_member_id")
-  matchId      Int      @map("match_id")
-  result       Result
-  recordedAt   DateTime @default(now()) @map("recorded_at")
+  id           Int       @id @default(autoincrement())
+  matchId      Int       @map("match_id")
+  roomMemberId Int       @map("room_member_id")
 
-  roomMember RoomMember @relation(fields: [roomMemberId], references: [id], onDelete: Restrict)
-  match      Match      @relation(fields: [matchId], references: [id], onDelete: Cascade)
+  score        Int?
+  placement    Int?
+  team         Team      @default(NONE)
+  outcome      Result?
+
+  awardedXp    Int       @default(0) @map("awarded_xp")
+  awardedCoin  Int       @default(0) @map("awarded_coin")
+  rewardedAt   DateTime? @map("rewarded_at")
+
+  recordedAt   DateTime  @default(now()) @map("recorded_at")
+
+  roomMember RoomMember  @relation(fields: [roomMemberId], references: [id], onDelete: Restrict)
+  match      Match       @relation(fields: [matchId], references: [id], onDelete: Cascade)
 
   @@unique([roomMemberId, matchId])
-  @@index([result])
+  @@index([outcome])
   @@index([recordedAt])
+  @@index([matchId])
   @@map("match_results")
 }
 

--- a/src/game/finished/constants/finished.constant.ts
+++ b/src/game/finished/constants/finished.constant.ts
@@ -1,0 +1,5 @@
+export const FINISHED_EVENTS = {
+  USER_REWARDS_GRANTED: 'user:rewardsGranted',
+  REWARDS_GRANTED: 'game.rewardsGranted',
+  ROOM_STATE_CHANGED: 'game.roomStateChanged',
+} as const;

--- a/src/game/finished/constants/finished.constant.ts
+++ b/src/game/finished/constants/finished.constant.ts
@@ -1,5 +1,7 @@
-export const FINISHED_EVENTS = {
-  USER_REWARDS_GRANTED: 'user:rewardsGranted',
+export const FINISHED_DOMAIN_EVENTS = {
   REWARDS_GRANTED: 'game.rewardsGranted',
-  ROOM_STATE_CHANGED: 'game.roomStateChanged',
+} as const;
+
+export const FINISHED_SOCKET_EVENTS = {
+  USER_REWARDS_GRANTED: 'user:rewardsGranted',
 } as const;

--- a/src/game/finished/dtos/responses/match-reward.dto.ts
+++ b/src/game/finished/dtos/responses/match-reward.dto.ts
@@ -1,5 +1,4 @@
-export interface RewardsGrantedEvent {
-  userId: number;
+export class MatchRewardResponseDto {
   matchId: number;
   exp: number;
   coin: number;

--- a/src/game/finished/finished-return.service.ts
+++ b/src/game/finished/finished-return.service.ts
@@ -62,8 +62,9 @@ export class FinishedReturnService {
           'returnToWaiting failed',
         );
       } else {
-        this.logger.error({ roomId, error }, 'returnToWaiting failed with unknown error');
+        this.logger.error({ roomId, error, message: String(error) }, 'returnToWaiting failed');
       }
+      throw error;
     } finally {
       this.cancel(roomId);
     }

--- a/src/game/finished/finished-return.service.ts
+++ b/src/game/finished/finished-return.service.ts
@@ -8,7 +8,7 @@ import {
 } from 'src/game-state/interfaces/game-state.interface';
 import { FinishedRepository } from './finished.repository';
 
-const FINISHED_HOLD_MS = 8000;
+const FINISHED_HOLD_MS = 8000; // 8초
 
 @Injectable()
 export class FinishedReturnService {
@@ -24,42 +24,45 @@ export class FinishedReturnService {
   schedule(roomId: number) {
     this.cancel(roomId);
 
-    const t = setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       void this.returnToWaiting(roomId);
     }, FINISHED_HOLD_MS);
 
-    this.timersByRoomId.set(roomId, t);
+    this.timersByRoomId.set(roomId, timeoutId);
   }
 
   cancel(roomId: number) {
-    const t = this.timersByRoomId.get(roomId);
-    if (t) {
-      clearTimeout(t);
+    const timeoutId = this.timersByRoomId.get(roomId);
+    if (timeoutId) {
+      clearTimeout(timeoutId);
       this.timersByRoomId.delete(roomId);
     }
   }
 
   private async returnToWaiting(roomId: number) {
     try {
-      const current = await this.gameStateStore.get(roomId);
-      if (!current || current.phase !== GamePhase.FINISHED) return;
+      const currentState = await this.gameStateStore.get(roomId);
+      if (!currentState || currentState.phase !== GamePhase.FINISHED) return;
 
-      const patched = await this.gameStateStore.patch(roomId, {
+      const patchedState = await this.gameStateStore.patch(roomId, {
         phase: GamePhase.WAITING,
         endsAt: null,
         phaseContext: null,
         currentTheme: null,
       });
-      if (!patched) return;
+      if (!patchedState) return;
 
       await this.finishedRepository.resetRoomToWaiting(roomId);
 
-      this.eventPublisher.broadcastGameState(roomId, patched);
-    } catch (e) {
-      if (e instanceof Error) {
-        this.logger.error({ roomId, message: e.message, stack: e.stack }, 'returnToWaiting failed');
+      this.eventPublisher.broadcastGameState(roomId, patchedState);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        this.logger.error(
+          { roomId, message: error.message, stack: error.stack },
+          'returnToWaiting failed',
+        );
       } else {
-        this.logger.error({ roomId, e }, 'returnToWaiting failed (non-Error thrown)');
+        this.logger.error({ roomId, error }, 'returnToWaiting failed with unknown error');
       }
     } finally {
       this.cancel(roomId);

--- a/src/game/finished/finished-return.service.ts
+++ b/src/game/finished/finished-return.service.ts
@@ -1,0 +1,68 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { GAME_EVENT_PUBLISHER } from 'src/game/interfaces/game-event-publisher.interfaces';
+import type { IGameEventPublisher } from 'src/game/interfaces/game-event-publisher.interfaces';
+import {
+  GAME_STATE_STORE,
+  GamePhase,
+  type IGameStateStore,
+} from 'src/game-state/interfaces/game-state.interface';
+import { FinishedRepository } from './finished.repository';
+
+const FINISHED_HOLD_MS = 8000;
+
+@Injectable()
+export class FinishedReturnService {
+  private readonly logger = new Logger(FinishedReturnService.name);
+  private readonly timersByRoomId = new Map<number, NodeJS.Timeout>();
+
+  constructor(
+    private readonly finishedRepository: FinishedRepository,
+    @Inject(GAME_STATE_STORE) private readonly gameStateStore: IGameStateStore,
+    @Inject(GAME_EVENT_PUBLISHER) private readonly eventPublisher: IGameEventPublisher,
+  ) {}
+
+  schedule(roomId: number) {
+    this.cancel(roomId);
+
+    const t = setTimeout(() => {
+      void this.returnToWaiting(roomId);
+    }, FINISHED_HOLD_MS);
+
+    this.timersByRoomId.set(roomId, t);
+  }
+
+  cancel(roomId: number) {
+    const t = this.timersByRoomId.get(roomId);
+    if (t) {
+      clearTimeout(t);
+      this.timersByRoomId.delete(roomId);
+    }
+  }
+
+  private async returnToWaiting(roomId: number) {
+    try {
+      const current = await this.gameStateStore.get(roomId);
+      if (!current || current.phase !== GamePhase.FINISHED) return;
+
+      const patched = await this.gameStateStore.patch(roomId, {
+        phase: GamePhase.WAITING,
+        endsAt: null,
+        phaseContext: null,
+        currentTheme: null,
+      });
+      if (!patched) return;
+
+      await this.finishedRepository.resetRoomToWaiting(roomId);
+
+      this.eventPublisher.broadcastGameState(roomId, patched);
+    } catch (e) {
+      if (e instanceof Error) {
+        this.logger.error({ roomId, message: e.message, stack: e.stack }, 'returnToWaiting failed');
+      } else {
+        this.logger.error({ roomId, e }, 'returnToWaiting failed (non-Error thrown)');
+      }
+    } finally {
+      this.cancel(roomId);
+    }
+  }
+}

--- a/src/game/finished/finished.gateway.ts
+++ b/src/game/finished/finished.gateway.ts
@@ -1,0 +1,36 @@
+import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
+import { Server } from 'socket.io';
+import { RoomStatus } from '@prisma/client';
+import { SocketExceptionFilter } from 'src/common/filters/socket-exception.filter';
+import { UseFilters } from '@nestjs/common';
+import { GAME_EVENTS } from '../constants/game.constant';
+import { FINISHED_EVENTS } from './constants/finished.constant';
+
+@UseFilters(SocketExceptionFilter)
+@WebSocketGateway({
+  cors: {
+    origin: process.env.CORS_ORIGINS ? process.env.CORS_ORIGINS.split(',') : [],
+    credentials: true,
+  },
+  namespace: '/game',
+})
+export class FinishedGateway {
+  @WebSocketServer() server: Server;
+
+  broadcastRoomState(roomId: number, status: RoomStatus) {
+    this.server
+      .to(this.roomRoomId(roomId))
+      .emit(GAME_EVENTS.ROOM_UPDATE_GAME_STATE, { roomId, status });
+  }
+
+  unicastRewards(userId: number, payload: { matchId: number; exp: number; coin: number }) {
+    this.server.to(this.userRoomId(userId)).emit(FINISHED_EVENTS.USER_REWARDS_GRANTED, payload);
+  }
+
+  private userRoomId(userId: number) {
+    return `user:${userId}`;
+  }
+  private roomRoomId(roomId: number) {
+    return `game:room:${roomId}`;
+  }
+}

--- a/src/game/finished/finished.gateway.ts
+++ b/src/game/finished/finished.gateway.ts
@@ -2,7 +2,7 @@ import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
 import { Server } from 'socket.io';
 import { SocketExceptionFilter } from 'src/common/filters/socket-exception.filter';
 import { UseFilters } from '@nestjs/common';
-import { FINISHED_EVENTS } from './constants/finished.constant';
+import { FINISHED_SOCKET_EVENTS } from './constants/finished.constant';
 import { MatchRewardResponseDto } from './dtos/responses/match-reward.dto';
 
 @UseFilters(SocketExceptionFilter)
@@ -17,13 +17,12 @@ export class FinishedGateway {
   @WebSocketServer() server: Server;
 
   unicastRewards(userId: number, payload: MatchRewardResponseDto) {
-    this.server.to(this.userRoomId(userId)).emit(FINISHED_EVENTS.USER_REWARDS_GRANTED, payload);
+    this.server
+      .to(this.userRoomId(userId))
+      .emit(FINISHED_SOCKET_EVENTS.USER_REWARDS_GRANTED, payload);
   }
 
   private userRoomId(userId: number) {
     return `user:${userId}`;
-  }
-  private roomRoomId(roomId: number) {
-    return `game:room:${roomId}`;
   }
 }

--- a/src/game/finished/finished.gateway.ts
+++ b/src/game/finished/finished.gateway.ts
@@ -23,7 +23,10 @@ export class FinishedGateway {
       .emit(GAME_EVENTS.ROOM_UPDATE_GAME_STATE, { roomId, status });
   }
 
-  unicastRewards(userId: number, payload: { matchId: number; exp: number; coin: number }) {
+  unicastRewards(
+    userId: number,
+    payload: { matchId: number; exp: number; coin: number; placement: number },
+  ) {
     this.server.to(this.userRoomId(userId)).emit(FINISHED_EVENTS.USER_REWARDS_GRANTED, payload);
   }
 

--- a/src/game/finished/finished.gateway.ts
+++ b/src/game/finished/finished.gateway.ts
@@ -1,10 +1,9 @@
 import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
 import { Server } from 'socket.io';
-import { RoomStatus } from '@prisma/client';
 import { SocketExceptionFilter } from 'src/common/filters/socket-exception.filter';
 import { UseFilters } from '@nestjs/common';
-import { GAME_EVENTS } from '../constants/game.constant';
 import { FINISHED_EVENTS } from './constants/finished.constant';
+import { MatchRewardResponseDto } from './dtos/responses/match-reward.dto';
 
 @UseFilters(SocketExceptionFilter)
 @WebSocketGateway({
@@ -17,16 +16,7 @@ import { FINISHED_EVENTS } from './constants/finished.constant';
 export class FinishedGateway {
   @WebSocketServer() server: Server;
 
-  broadcastRoomState(roomId: number, status: RoomStatus) {
-    this.server
-      .to(this.roomRoomId(roomId))
-      .emit(GAME_EVENTS.ROOM_UPDATE_GAME_STATE, { roomId, status });
-  }
-
-  unicastRewards(
-    userId: number,
-    payload: { matchId: number; exp: number; coin: number; placement: number },
-  ) {
+  unicastRewards(userId: number, payload: MatchRewardResponseDto) {
     this.server.to(this.userRoomId(userId)).emit(FINISHED_EVENTS.USER_REWARDS_GRANTED, payload);
   }
 

--- a/src/game/finished/finished.repository.ts
+++ b/src/game/finished/finished.repository.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma, PrismaClient, RoomStatus, MatchStatus } from '@prisma/client';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class FinishedRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async markMatchCompleted(matchId: number, now = new Date()) {
+    return this.prisma.match.updateMany({
+      where: { id: matchId, status: { not: MatchStatus.COMPLETED } },
+      data: { status: MatchStatus.COMPLETED, endedAt: now },
+    });
+  }
+
+  async upsertMatchResult(
+    tx: PrismaClient | Prisma.TransactionClient,
+    params: { matchId: number; roomMemberId: number; score: number; placement: number },
+  ) {
+    const { matchId, roomMemberId, score, placement } = params;
+
+    return tx.matchResult.upsert({
+      where: { roomMemberId_matchId: { roomMemberId, matchId } },
+      create: { matchId, roomMemberId, score, placement },
+      update: { score, placement },
+      select: { id: true, rewardedAt: true },
+    });
+  }
+
+  async confirmRewardOnce(
+    tx: PrismaClient | Prisma.TransactionClient,
+    params: { matchResultId: number; xp: number; coin: number; now?: Date },
+  ) {
+    const { matchResultId, xp, coin, now = new Date() } = params;
+
+    return tx.matchResult.updateMany({
+      where: { id: matchResultId, rewardedAt: null },
+      data: { awardedXp: xp, awardedCoin: coin, rewardedAt: now },
+    });
+  }
+
+  async incrementUserProfile(
+    tx: PrismaClient | Prisma.TransactionClient,
+    params: { userId: number; xp: number; coin: number },
+  ) {
+    const { userId, xp, coin } = params;
+
+    return tx.userProfile.update({
+      where: { userId },
+      data: {
+        experience: { increment: xp },
+        coin: { increment: coin },
+      },
+    });
+  }
+
+  async resetRoomToWaiting(roomId: number) {
+    return this.prisma.$transaction(async (tx) => {
+      await tx.room.update({
+        where: { id: roomId },
+        data: { status: RoomStatus.WAITING },
+      });
+
+      await tx.roomMember.updateMany({
+        where: { roomId },
+        data: { isReady: false },
+      });
+    });
+  }
+
+  async transaction<T>(fn: (tx: Prisma.TransactionClient) => Promise<T>) {
+    return this.prisma.$transaction(fn);
+  }
+}

--- a/src/game/finished/finished.repository.ts
+++ b/src/game/finished/finished.repository.ts
@@ -1,13 +1,18 @@
 import { Injectable } from '@nestjs/common';
 import { Prisma, PrismaClient, RoomStatus, MatchStatus } from '@prisma/client';
 import { PrismaService } from 'src/prisma/prisma.service';
+import {
+  UpsertMatchResultParams,
+  ConfirmRewardParams,
+  IncrementUserProfileParams,
+} from './interfaces/finished.interface';
 
 @Injectable()
 export class FinishedRepository {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(private readonly prismaService: PrismaService) {}
 
   async markMatchCompleted(matchId: number, now = new Date()) {
-    return this.prisma.match.updateMany({
+    return this.prismaService.match.updateMany({
       where: { id: matchId, status: { not: MatchStatus.COMPLETED } },
       data: { status: MatchStatus.COMPLETED, endedAt: now },
     });
@@ -15,10 +20,9 @@ export class FinishedRepository {
 
   async upsertMatchResult(
     tx: PrismaClient | Prisma.TransactionClient,
-    params: { matchId: number; roomMemberId: number; score: number; placement: number },
+    params: UpsertMatchResultParams,
   ) {
     const { matchId, roomMemberId, score, placement } = params;
-
     return tx.matchResult.upsert({
       where: { roomMemberId_matchId: { roomMemberId, matchId } },
       create: { matchId, roomMemberId, score, placement },
@@ -29,38 +33,32 @@ export class FinishedRepository {
 
   async confirmRewardOnce(
     tx: PrismaClient | Prisma.TransactionClient,
-    params: { matchResultId: number; xp: number; coin: number; now?: Date },
+    params: ConfirmRewardParams,
   ) {
-    const { matchResultId, xp, coin, now = new Date() } = params;
-
+    const { matchResultId, exp, coin, now = new Date() } = params;
     return tx.matchResult.updateMany({
       where: { id: matchResultId, rewardedAt: null },
-      data: { awardedXp: xp, awardedCoin: coin, rewardedAt: now },
+      data: { awardedXp: exp, awardedCoin: coin, rewardedAt: now },
     });
   }
 
   async incrementUserProfile(
     tx: PrismaClient | Prisma.TransactionClient,
-    params: { userId: number; xp: number; coin: number },
+    params: IncrementUserProfileParams,
   ) {
-    const { userId, xp, coin } = params;
-
+    const { userId, exp, coin } = params;
     return tx.userProfile.update({
       where: { userId },
-      data: {
-        experience: { increment: xp },
-        coin: { increment: coin },
-      },
+      data: { experience: { increment: exp }, coin: { increment: coin } },
     });
   }
 
   async resetRoomToWaiting(roomId: number) {
-    return this.prisma.$transaction(async (tx) => {
+    return this.prismaService.$transaction(async (tx) => {
       await tx.room.update({
         where: { id: roomId },
         data: { status: RoomStatus.WAITING },
       });
-
       await tx.roomMember.updateMany({
         where: { roomId },
         data: { isReady: false },
@@ -69,6 +67,6 @@ export class FinishedRepository {
   }
 
   async transaction<T>(fn: (tx: Prisma.TransactionClient) => Promise<T>) {
-    return this.prisma.$transaction(fn);
+    return this.prismaService.$transaction(fn);
   }
 }

--- a/src/game/finished/interfaces/finishde.interface.ts
+++ b/src/game/finished/interfaces/finishde.interface.ts
@@ -1,13 +1,7 @@
-import { RoomStatus } from '@prisma/client';
-
 export interface RewardsGrantedEvent {
   userId: number;
   matchId: number;
   exp: number;
   coin: number;
-}
-
-export interface RoomStateChangedEvent {
-  roomId: number;
-  status: RoomStatus;
+  placement: number;
 }

--- a/src/game/finished/interfaces/finishde.interface.ts
+++ b/src/game/finished/interfaces/finishde.interface.ts
@@ -1,0 +1,13 @@
+import { RoomStatus } from '@prisma/client';
+
+export interface RewardsGrantedEvent {
+  userId: number;
+  matchId: number;
+  exp: number;
+  coin: number;
+}
+
+export interface RoomStateChangedEvent {
+  roomId: number;
+  status: RoomStatus;
+}

--- a/src/game/finished/interfaces/finished.interface.ts
+++ b/src/game/finished/interfaces/finished.interface.ts
@@ -1,0 +1,39 @@
+import { FinalResultItem } from '../types/finished.type';
+
+export interface MatchFinalizeParams {
+  matchId: number;
+  finalResults: FinalResultItem[];
+  roomMemberIdByUserId: Record<string, number>;
+}
+
+export interface MatchLifecycleParams extends MatchFinalizeParams {
+  roomId: number;
+}
+
+export interface RewardsGrantedEventPayload {
+  userId: number;
+  matchId: number;
+  exp: number;
+  coin: number;
+  placement: number;
+}
+
+export interface UpsertMatchResultParams {
+  matchId: number;
+  roomMemberId: number;
+  score: number;
+  placement: number;
+}
+
+export interface ConfirmRewardParams {
+  matchResultId: number;
+  exp: number;
+  coin: number;
+  now?: Date;
+}
+
+export interface IncrementUserProfileParams {
+  userId: number;
+  exp: number;
+  coin: number;
+}

--- a/src/game/finished/match-finalize.service.ts
+++ b/src/game/finished/match-finalize.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { rewardByPlacement } from './policies/reward.policy';
-import { FINISHED_EVENTS } from './constants/finished.constant';
+import { FINISHED_DOMAIN_EVENTS } from './constants/finished.constant';
 import { FinishedRepository } from './finished.repository';
 import { MatchFinalizeParams, RewardsGrantedEventPayload } from './interfaces/finished.interface';
 import { FinalRewardsByUserId } from './types/finished.type';
@@ -18,8 +18,10 @@ export class MatchFinalizeService {
 
     const finalRewards: FinalRewardsByUserId = {};
     for (const result of finalResults) {
-      const { exp, coin } = rewardByPlacement(result.placement || 9999);
-      finalRewards[String(result.userId)] = { exp, coin };
+      const validPlacement = result.placement || undefined;
+      const { exp, coin } = rewardByPlacement(validPlacement);
+
+      finalRewards[result.userId] = { exp, coin };
     }
 
     const notifications = await this.finishedRepository.transaction(async (tx) => {
@@ -42,7 +44,7 @@ export class MatchFinalizeService {
 
         if (upserted.rewardedAt != null) continue;
 
-        const { exp, coin } = rewardByPlacement(placement || 9999);
+        const { exp, coin } = finalRewards[userId];
 
         const updated = await this.finishedRepository.confirmRewardOnce(tx, {
           matchResultId: upserted.id,
@@ -61,7 +63,7 @@ export class MatchFinalizeService {
     });
 
     for (const payload of notifications) {
-      this.eventEmitter.emit(FINISHED_EVENTS.REWARDS_GRANTED, payload);
+      this.eventEmitter.emit(FINISHED_DOMAIN_EVENTS.REWARDS_GRANTED, payload);
     }
 
     return finalRewards;

--- a/src/game/finished/match-finalize.service.ts
+++ b/src/game/finished/match-finalize.service.ts
@@ -1,0 +1,85 @@
+import { Injectable } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { rewardByPlacement } from './policies/reward.policy';
+import { FINISHED_EVENTS } from './constants/finished.constant';
+import { FinishedRepository } from './finished.repository';
+
+type FinalResultItem = { userId: number; score: number; placement: number };
+type FinalRewardsByUserId = Record<string, { exp: number; coin: number }>;
+
+@Injectable()
+export class MatchFinalizeService {
+  constructor(
+    private readonly repo: FinishedRepository,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  async finalizeFromFinalResults(params: {
+    matchId: number;
+    finalResults: FinalResultItem[];
+    roomMemberIdByUserId: Record<string, number>;
+  }): Promise<FinalRewardsByUserId> {
+    const { matchId, finalResults, roomMemberIdByUserId } = params;
+
+    // 브로드캐스트용: 전원 보상표(정책 기반)
+    const finalRewards: FinalRewardsByUserId = {};
+    for (const r of finalResults) {
+      const { xp, coin } = rewardByPlacement(r.placement || 9999);
+      finalRewards[String(r.userId)] = { exp: xp, coin };
+    }
+
+    // 커밋 후 유니캐스트 emit 목록
+    const notifications = await this.repo.transaction(async (tx) => {
+      const noti: Array<{
+        userId: number;
+        matchId: number;
+        exp: number;
+        coin: number;
+        placement: number;
+      }> = [];
+
+      for (const item of finalResults) {
+        const userId = Number(item.userId);
+        const memberId = roomMemberIdByUserId[String(userId)];
+        if (!memberId) continue;
+
+        const score = Number(item.score ?? 0);
+        const placement = Number(item.placement ?? 0) || 0;
+
+        const upserted = await this.repo.upsertMatchResult(tx, {
+          matchId,
+          roomMemberId: memberId,
+          score,
+          placement,
+        });
+
+        // 이미 지급했으면 스킵
+        if (upserted.rewardedAt != null) continue;
+
+        const { xp, coin } = rewardByPlacement(placement || 9999);
+
+        const updated = await this.repo.confirmRewardOnce(tx, {
+          matchResultId: upserted.id,
+          xp,
+          coin,
+        });
+
+        if (updated.count !== 1) continue;
+
+        await this.repo.incrementUserProfile(tx, { userId, xp, coin });
+
+        noti.push({ userId, matchId, exp: xp, coin, placement });
+      }
+
+      return noti;
+    });
+
+    // 커밋 후 유니캐스트 이벤트
+    for (const n of notifications) {
+      this.eventEmitter.emit(FINISHED_EVENTS.REWARDS_GRANTED, n);
+    }
+
+    // 브로드캐스트용 리턴
+    return finalRewards;
+  }
+}

--- a/src/game/finished/match-finalize.service.ts
+++ b/src/game/finished/match-finalize.service.ts
@@ -3,83 +3,67 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { rewardByPlacement } from './policies/reward.policy';
 import { FINISHED_EVENTS } from './constants/finished.constant';
 import { FinishedRepository } from './finished.repository';
-
-type FinalResultItem = { userId: number; score: number; placement: number };
-type FinalRewardsByUserId = Record<string, { exp: number; coin: number }>;
+import { MatchFinalizeParams, RewardsGrantedEventPayload } from './interfaces/finished.interface';
+import { FinalRewardsByUserId } from './types/finished.type';
 
 @Injectable()
 export class MatchFinalizeService {
   constructor(
-    private readonly repo: FinishedRepository,
+    private readonly finishedRepository: FinishedRepository,
     private readonly eventEmitter: EventEmitter2,
   ) {}
 
-  async finalizeFromFinalResults(params: {
-    matchId: number;
-    finalResults: FinalResultItem[];
-    roomMemberIdByUserId: Record<string, number>;
-  }): Promise<FinalRewardsByUserId> {
+  async finalizeFromFinalResults(params: MatchFinalizeParams): Promise<FinalRewardsByUserId> {
     const { matchId, finalResults, roomMemberIdByUserId } = params;
 
-    // 브로드캐스트용: 전원 보상표(정책 기반)
     const finalRewards: FinalRewardsByUserId = {};
-    for (const r of finalResults) {
-      const { xp, coin } = rewardByPlacement(r.placement || 9999);
-      finalRewards[String(r.userId)] = { exp: xp, coin };
+    for (const result of finalResults) {
+      const { exp, coin } = rewardByPlacement(result.placement || 9999);
+      finalRewards[String(result.userId)] = { exp, coin };
     }
 
-    // 커밋 후 유니캐스트 emit 목록
-    const notifications = await this.repo.transaction(async (tx) => {
-      const noti: Array<{
-        userId: number;
-        matchId: number;
-        exp: number;
-        coin: number;
-        placement: number;
-      }> = [];
+    const notifications = await this.finishedRepository.transaction(async (tx) => {
+      const eventPayloads: RewardsGrantedEventPayload[] = [];
 
-      for (const item of finalResults) {
-        const userId = Number(item.userId);
+      for (const userResult of finalResults) {
+        const userId = Number(userResult.userId);
         const memberId = roomMemberIdByUserId[String(userId)];
         if (!memberId) continue;
 
-        const score = Number(item.score ?? 0);
-        const placement = Number(item.placement ?? 0) || 0;
+        const score = Number(userResult.score ?? 0);
+        const placement = Number(userResult.placement ?? 0) || 0;
 
-        const upserted = await this.repo.upsertMatchResult(tx, {
+        const upserted = await this.finishedRepository.upsertMatchResult(tx, {
           matchId,
           roomMemberId: memberId,
           score,
           placement,
         });
 
-        // 이미 지급했으면 스킵
         if (upserted.rewardedAt != null) continue;
 
-        const { xp, coin } = rewardByPlacement(placement || 9999);
+        const { exp, coin } = rewardByPlacement(placement || 9999);
 
-        const updated = await this.repo.confirmRewardOnce(tx, {
+        const updated = await this.finishedRepository.confirmRewardOnce(tx, {
           matchResultId: upserted.id,
-          xp,
+          exp,
           coin,
         });
 
         if (updated.count !== 1) continue;
 
-        await this.repo.incrementUserProfile(tx, { userId, xp, coin });
+        await this.finishedRepository.incrementUserProfile(tx, { userId, exp, coin });
 
-        noti.push({ userId, matchId, exp: xp, coin, placement });
+        eventPayloads.push({ userId, matchId, exp, coin, placement });
       }
 
-      return noti;
+      return eventPayloads;
     });
 
-    // 커밋 후 유니캐스트 이벤트
-    for (const n of notifications) {
-      this.eventEmitter.emit(FINISHED_EVENTS.REWARDS_GRANTED, n);
+    for (const payload of notifications) {
+      this.eventEmitter.emit(FINISHED_EVENTS.REWARDS_GRANTED, payload);
     }
 
-    // 브로드캐스트용 리턴
     return finalRewards;
   }
 }

--- a/src/game/finished/match-lifecycle.service.ts
+++ b/src/game/finished/match-lifecycle.service.ts
@@ -1,26 +1,21 @@
 import { Injectable } from '@nestjs/common';
 import { MatchFinalizeService } from './match-finalize.service';
 import { FinishedRepository } from './finished.repository';
-
-type FinalResultItem = { userId: number; score: number; placement: number };
-type FinalRewardsByUserId = Record<string, { exp: number; coin: number }>;
+import { FinalRewardsByUserId } from './types/finished.type';
+import { MatchLifecycleParams } from './interfaces/finished.interface';
 
 @Injectable()
 export class MatchLifecycleService {
   constructor(
-    private readonly repo: FinishedRepository,
+    private readonly finishedRepository: FinishedRepository,
     private readonly finalizeService: MatchFinalizeService,
   ) {}
 
-  async onGameFinished(params: {
-    roomId: number;
-    matchId: number;
-    finalResults: FinalResultItem[];
-    roomMemberIdByUserId: Record<string, number>;
-  }): Promise<FinalRewardsByUserId> {
+  // 매치 종료 처리: 결과 저장, 보상 계산 및 지급
+  async onGameFinished(params: MatchLifecycleParams): Promise<FinalRewardsByUserId> {
     const { matchId, finalResults, roomMemberIdByUserId } = params;
 
-    await this.repo.markMatchCompleted(matchId);
+    await this.finishedRepository.markMatchCompleted(matchId);
 
     return this.finalizeService.finalizeFromFinalResults({
       matchId,

--- a/src/game/finished/match-lifecycle.service.ts
+++ b/src/game/finished/match-lifecycle.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { MatchFinalizeService } from './match-finalize.service';
+import { FinishedRepository } from './finished.repository';
+
+type FinalResultItem = { userId: number; score: number; placement: number };
+type FinalRewardsByUserId = Record<string, { exp: number; coin: number }>;
+
+@Injectable()
+export class MatchLifecycleService {
+  constructor(
+    private readonly repo: FinishedRepository,
+    private readonly finalizeService: MatchFinalizeService,
+  ) {}
+
+  async onGameFinished(params: {
+    roomId: number;
+    matchId: number;
+    finalResults: FinalResultItem[];
+    roomMemberIdByUserId: Record<string, number>;
+  }): Promise<FinalRewardsByUserId> {
+    const { matchId, finalResults, roomMemberIdByUserId } = params;
+
+    await this.repo.markMatchCompleted(matchId);
+
+    return this.finalizeService.finalizeFromFinalResults({
+      matchId,
+      finalResults,
+      roomMemberIdByUserId,
+    });
+  }
+}

--- a/src/game/finished/policies/reward.policy.ts
+++ b/src/game/finished/policies/reward.policy.ts
@@ -1,16 +1,22 @@
-export type Reward = { xp: number; coin: number };
+export type Reward = { exp: number; coin: number };
 
 export function rewardByPlacement(placement?: number | null): Reward {
-  if (!placement) return { xp: 0, coin: 0 };
+  if (!placement) return { exp: 0, coin: 0 };
 
   switch (placement) {
     case 1:
-      return { xp: 120, coin: 80 };
+      return { exp: 120, coin: 80 };
     case 2:
-      return { xp: 90, coin: 60 };
+      return { exp: 90, coin: 60 };
     case 3:
-      return { xp: 70, coin: 45 };
+      return { exp: 70, coin: 45 };
+    case 4:
+      return { exp: 50, coin: 30 };
+    case 5:
+      return { exp: 40, coin: 25 };
+    case 6:
+      return { exp: 30, coin: 20 };
     default:
-      return { xp: 40, coin: 25 };
+      return { exp: 30, coin: 20 };
   }
 }

--- a/src/game/finished/policies/reward.policy.ts
+++ b/src/game/finished/policies/reward.policy.ts
@@ -1,0 +1,16 @@
+export type Reward = { xp: number; coin: number };
+
+export function rewardByPlacement(placement?: number | null): Reward {
+  if (!placement) return { xp: 0, coin: 0 };
+
+  switch (placement) {
+    case 1:
+      return { xp: 120, coin: 80 };
+    case 2:
+      return { xp: 90, coin: 60 };
+    case 3:
+      return { xp: 70, coin: 45 };
+    default:
+      return { xp: 40, coin: 25 };
+  }
+}

--- a/src/game/finished/policies/reward.policy.ts
+++ b/src/game/finished/policies/reward.policy.ts
@@ -1,22 +1,18 @@
 export type Reward = { exp: number; coin: number };
 
-export function rewardByPlacement(placement?: number | null): Reward {
-  if (!placement) return { exp: 0, coin: 0 };
+const REWARD_TABLE: Record<number, Reward> = {
+  1: { exp: 120, coin: 80 },
+  2: { exp: 90, coin: 60 },
+  3: { exp: 70, coin: 45 },
+  4: { exp: 50, coin: 30 },
+  5: { exp: 40, coin: 25 },
+  6: { exp: 30, coin: 20 },
+};
 
-  switch (placement) {
-    case 1:
-      return { exp: 120, coin: 80 };
-    case 2:
-      return { exp: 90, coin: 60 };
-    case 3:
-      return { exp: 70, coin: 45 };
-    case 4:
-      return { exp: 50, coin: 30 };
-    case 5:
-      return { exp: 40, coin: 25 };
-    case 6:
-      return { exp: 30, coin: 20 };
-    default:
-      return { exp: 30, coin: 20 };
+export function rewardByPlacement(placement: number | undefined): Reward {
+  if (placement === undefined) {
+    return { exp: 0, coin: 0 };
   }
+
+  return REWARD_TABLE[placement] ?? { exp: 30, coin: 20 };
 }

--- a/src/game/finished/socket-events.listener.ts
+++ b/src/game/finished/socket-events.listener.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import type { RewardsGrantedEvent } from './interfaces/finishde.interface';
+import { FinishedGateway } from './finished.gateway';
+import { FINISHED_EVENTS } from './constants/finished.constant';
+
+@Injectable()
+export class FinishedEventsListener {
+  constructor(private readonly socket: FinishedGateway) {}
+
+  @OnEvent(FINISHED_EVENTS.REWARDS_GRANTED)
+  onRewardsGranted(event: RewardsGrantedEvent) {
+    this.socket.unicastRewards(event.userId, {
+      matchId: event.matchId,
+      exp: event.exp,
+      coin: event.coin,
+      placement: event.placement,
+    });
+  }
+}

--- a/src/game/finished/socket-events.listener.ts
+++ b/src/game/finished/socket-events.listener.ts
@@ -2,13 +2,13 @@ import { Injectable } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
 import type { RewardsGrantedEventPayload } from './interfaces/finished.interface';
 import { FinishedGateway } from './finished.gateway';
-import { FINISHED_EVENTS } from './constants/finished.constant';
+import { FINISHED_DOMAIN_EVENTS } from './constants/finished.constant';
 
 @Injectable()
 export class FinishedEventsListener {
   constructor(private readonly socket: FinishedGateway) {}
 
-  @OnEvent(FINISHED_EVENTS.REWARDS_GRANTED)
+  @OnEvent(FINISHED_DOMAIN_EVENTS.REWARDS_GRANTED)
   onRewardsGranted(event: RewardsGrantedEventPayload) {
     this.socket.unicastRewards(event.userId, {
       matchId: event.matchId,

--- a/src/game/finished/socket-events.listener.ts
+++ b/src/game/finished/socket-events.listener.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
-import type { RewardsGrantedEvent } from './interfaces/finishde.interface';
+import type { RewardsGrantedEventPayload } from './interfaces/finished.interface';
 import { FinishedGateway } from './finished.gateway';
 import { FINISHED_EVENTS } from './constants/finished.constant';
 
@@ -9,7 +9,7 @@ export class FinishedEventsListener {
   constructor(private readonly socket: FinishedGateway) {}
 
   @OnEvent(FINISHED_EVENTS.REWARDS_GRANTED)
-  onRewardsGranted(event: RewardsGrantedEvent) {
+  onRewardsGranted(event: RewardsGrantedEventPayload) {
     this.socket.unicastRewards(event.userId, {
       matchId: event.matchId,
       exp: event.exp,

--- a/src/game/finished/types/finished.type.ts
+++ b/src/game/finished/types/finished.type.ts
@@ -4,4 +4,4 @@ export type FinalResultItem = {
   placement: number;
 };
 
-export type FinalRewardsByUserId = Record<string, { exp: number; coin: number }>;
+export type FinalRewardsByUserId = Record<number, { exp: number; coin: number }>;

--- a/src/game/finished/types/finished.type.ts
+++ b/src/game/finished/types/finished.type.ts
@@ -1,0 +1,7 @@
+export type FinalResultItem = {
+  userId: number;
+  score: number;
+  placement: number;
+};
+
+export type FinalRewardsByUserId = Record<string, { exp: number; coin: number }>;

--- a/src/game/game.module.ts
+++ b/src/game/game.module.ts
@@ -25,6 +25,7 @@ import { EvaluationService } from './evaluation/evaluation.service';
 import { EvaluationVoteRepository } from './evaluation/evaluation-vote.repository';
 import { EVALUATION_VOTE } from './evaluation/interfaces/evaluation-vote.interface';
 import { RoundSummaryService } from './round-summary/round-summary.service';
+import { FinishedGateway } from './finished/finished.gateway';
 
 @Module({
   imports: [
@@ -61,6 +62,7 @@ import { RoundSummaryService } from './round-summary/round-summary.service';
     EvaluationService,
     { provide: EVALUATION_VOTE, useClass: EvaluationVoteRepository },
     RoundSummaryService,
+    FinishedGateway,
   ],
   exports: [],
 })

--- a/src/game/game.module.ts
+++ b/src/game/game.module.ts
@@ -26,6 +26,11 @@ import { EvaluationVoteRepository } from './evaluation/evaluation-vote.repositor
 import { EVALUATION_VOTE } from './evaluation/interfaces/evaluation-vote.interface';
 import { RoundSummaryService } from './round-summary/round-summary.service';
 import { FinishedGateway } from './finished/finished.gateway';
+import { FinishedReturnService } from './finished/finished-return.service';
+import { MatchLifecycleService } from './finished/match-lifecycle.service';
+import { MatchFinalizeService } from './finished/match-finalize.service';
+import { FinishedRepository } from './finished/finished.repository';
+import { FinishedEventsListener } from './finished/socket-events.listener';
 
 @Module({
   imports: [
@@ -63,6 +68,11 @@ import { FinishedGateway } from './finished/finished.gateway';
     { provide: EVALUATION_VOTE, useClass: EvaluationVoteRepository },
     RoundSummaryService,
     FinishedGateway,
+    FinishedReturnService,
+    MatchFinalizeService,
+    MatchLifecycleService,
+    FinishedEventsListener,
+    FinishedRepository,
   ],
   exports: [],
 })

--- a/src/game/session/game-session.service.ts
+++ b/src/game/session/game-session.service.ts
@@ -21,6 +21,7 @@ import { wsError } from 'src/common/utils/ws-error.util';
 import { EvaluationService } from '../evaluation/evaluation.service';
 import { MatchLifecycleService } from '../finished/match-lifecycle.service';
 import { FinishedReturnService } from '../finished/finished-return.service';
+import { FinalRewardsByUserId } from '../finished/types/finished.type';
 
 type GameRemoteSocket = RemoteSocket<DefaultEventsMap, GameSocketData>;
 
@@ -28,7 +29,6 @@ const THEME_SELECTING_DURATION_MS = 32000; // 32초
 const DRAWING_DURATION_MS = 92000; // 92초
 const EVALUATING_DURATION_MS = 60000; // 60초
 const ROUND_SUMMARY_DURATION_MS = 32000; // 32초
-const FINISHED_HOLD_MS = 8000; // 8초
 
 @Injectable()
 export class GameSessionService {
@@ -333,7 +333,7 @@ export class GameSessionService {
         const finalScoresByUserId = this.computeFinalScoresByUserId(patched);
         const finalResults = this.buildFinalResults(finalScoresByUserId);
 
-        let finalRewards: Record<string, { exp: number; coin: number }> = {};
+        let finalRewards: FinalRewardsByUserId = {};
 
         if (typeof patched.matchId === 'number') {
           finalRewards = await this.matchLifecycleService.onGameFinished({
@@ -344,7 +344,7 @@ export class GameSessionService {
           });
         }
 
-        const { totalScores, ...rest } = patched as any;
+        const { totalScores, ...rest } = patched;
 
         this.eventPublisher.broadcastGameState(roomId, {
           ...rest,
@@ -379,8 +379,6 @@ export class GameSessionService {
 
   private readonly roundSummaryExitGuard = new Set<number>();
 
-  private readonly finishedReturnTimersByRoomId = new Map<number, NodeJS.Timeout>();
-
   private roomSocketRoom(roomId: number) {
     return `game:room:${roomId}`;
   }
@@ -391,15 +389,6 @@ export class GameSessionService {
     if (timer) {
       clearTimeout(timer);
       this.phaseTransitionTimersByRoomId.delete(roomId);
-    }
-  }
-
-  // FINISHED 복귀 타이머 해제
-  private clearFinishedReturnTimer(roomId: number) {
-    const timer = this.finishedReturnTimersByRoomId.get(roomId);
-    if (timer) {
-      clearTimeout(timer);
-      this.finishedReturnTimersByRoomId.delete(roomId);
     }
   }
 

--- a/src/game/session/game-session.service.ts
+++ b/src/game/session/game-session.service.ts
@@ -26,6 +26,7 @@ const THEME_SELECTING_DURATION_MS = 32000; // 32초
 const DRAWING_DURATION_MS = 92000; // 92초
 const EVALUATING_DURATION_MS = 60000; // 60초
 const ROUND_SUMMARY_DURATION_MS = 32000; // 32초
+const FINISHED_HOLD_MS = 8000; // 8초
 
 @Injectable()
 export class GameSessionService {
@@ -331,6 +332,9 @@ export class GameSessionService {
           ...patched,
           finalScoresByUserId,
         });
+
+        this.scheduleReturnToWaitingAfterFinished(roomId);
+
         return;
       }
 
@@ -357,6 +361,8 @@ export class GameSessionService {
 
   private readonly roundSummaryExitGuard = new Set<number>();
 
+  private readonly finishedReturnTimersByRoomId = new Map<number, NodeJS.Timeout>();
+
   private roomSocketRoom(roomId: number) {
     return `game:room:${roomId}`;
   }
@@ -367,6 +373,15 @@ export class GameSessionService {
     if (timer) {
       clearTimeout(timer);
       this.phaseTransitionTimersByRoomId.delete(roomId);
+    }
+  }
+
+  // FINISHED 복귀 타이머 해제
+  private clearFinishedReturnTimer(roomId: number) {
+    const timer = this.finishedReturnTimersByRoomId.get(roomId);
+    if (timer) {
+      clearTimeout(timer);
+      this.finishedReturnTimersByRoomId.delete(roomId);
     }
   }
 
@@ -502,5 +517,53 @@ export class GameSessionService {
     }
 
     return out;
+  }
+
+  private scheduleReturnToWaitingAfterFinished(roomId: number) {
+    // room당 1개만 유지
+    this.clearFinishedReturnTimer(roomId);
+
+    const timer = setTimeout(() => {
+      void (async () => {
+        try {
+          const current = await this.gameStateStore.get(roomId);
+          if (!current) return;
+
+          // 아직 FINISHED일 때만 대기실로 전환
+          if (current.phase !== GamePhase.FINISHED) return;
+
+          // 다른 phase 전환 타이머가 남아있을 수 있으니 정리
+          this.clearPhaseTimer(roomId);
+
+          const patched = await this.gameStateStore.patch(roomId, {
+            phase: GamePhase.WAITING, // ✅ 실제 대기 phase로 변경(예: LOBBY)
+            endsAt: null,
+            phaseContext: null,
+            currentTheme: null,
+          });
+
+          if (!patched) return;
+
+          // eventPublisher가 내부적으로 server.to(...).emit(...) 하므로 server 인자 불필요
+          this.eventPublisher.broadcastGameState(roomId, patched);
+        } catch (error: unknown) {
+          if (error instanceof Error) {
+            this.logger.error(
+              { message: error.message, stack: error.stack, roomId },
+              'scheduleReturnToWaitingAfterFinished timeout handler failed',
+            );
+          } else {
+            this.logger.error(
+              { error, roomId },
+              'scheduleReturnToWaitingAfterFinished timeout handler failed (non-Error thrown)',
+            );
+          }
+        } finally {
+          this.clearFinishedReturnTimer(roomId);
+        }
+      })();
+    }, FINISHED_HOLD_MS);
+
+    this.finishedReturnTimersByRoomId.set(roomId, timer);
   }
 }

--- a/src/game/session/game-session.service.ts
+++ b/src/game/session/game-session.service.ts
@@ -526,31 +526,31 @@ export class GameSessionService {
     return out;
   }
 
-  private buildFinalResults(finalScoresByUserId: Record<string, number>) {
-    const items = Object.entries(finalScoresByUserId)
-      .map(([userId, score]) => ({ userId: Number(userId), score: Number(score) }))
+  // userId, score, placement 포함한 최종 결과 리스트 구성
+  private buildFinalResults(
+    finalScoresByUserId: Record<string, number>,
+  ): Array<{ userId: number; score: number; placement: number }> {
+    const sorted = Object.entries(finalScoresByUserId)
+      .map(([userId, score]) => ({
+        userId: Number(userId),
+        score: Number(score),
+      }))
       .sort((a, b) => b.score - a.score);
 
-    const out: Array<{ userId: number; score: number; placement: number }> = [];
+    let lastScore: number | null = null;
+    let lastPlacement = 0;
 
-    let prevScore: number | null = null;
-    let prevPlacement = 0;
-
-    for (let i = 0; i < items.length; i++) {
-      const { userId, score } = items[i];
-
-      let placement: number;
-      if (prevScore !== null && score === prevScore) {
-        placement = prevPlacement;
-      } else {
-        placement = i + 1;
-        prevScore = score;
-        prevPlacement = placement;
+    return sorted.map((item, index) => {
+      if (item.score !== lastScore) {
+        lastPlacement = index + 1;
+        lastScore = item.score;
       }
 
-      out.push({ userId, score, placement });
-    }
-
-    return out;
+      return {
+        userId: item.userId,
+        score: item.score,
+        placement: lastPlacement,
+      };
+    });
   }
 }

--- a/src/game/session/game-session.service.ts
+++ b/src/game/session/game-session.service.ts
@@ -19,6 +19,8 @@ import { DrawingService } from '../drawing/drawing.service';
 import { GameSocketData } from '../interfaces/gameSocket.interface';
 import { wsError } from 'src/common/utils/ws-error.util';
 import { EvaluationService } from '../evaluation/evaluation.service';
+import { MatchLifecycleService } from '../finished/match-lifecycle.service';
+import { FinishedReturnService } from '../finished/finished-return.service';
 
 type GameRemoteSocket = RemoteSocket<DefaultEventsMap, GameSocketData>;
 
@@ -36,6 +38,8 @@ export class GameSessionService {
     private readonly topicService: TopicService,
     private readonly drawingService: DrawingService,
     private readonly evaluationService: EvaluationService,
+    private readonly matchLifecycleService: MatchLifecycleService,
+    private readonly finishedReturnService: FinishedReturnService,
     @Inject(GAME_STATE_STORE) private readonly gameStateStore: IGameStateStore,
     @Inject(GAME_EVENT_PUBLISHER) private readonly eventPublisher: IGameEventPublisher,
   ) {}
@@ -327,14 +331,28 @@ export class GameSessionService {
 
       if (patched.phase === GamePhase.FINISHED) {
         const finalScoresByUserId = this.computeFinalScoresByUserId(patched);
+        const finalResults = this.buildFinalResults(finalScoresByUserId);
+
+        let finalRewards: Record<string, { exp: number; coin: number }> = {};
+
+        if (typeof patched.matchId === 'number') {
+          finalRewards = await this.matchLifecycleService.onGameFinished({
+            roomId,
+            matchId: patched.matchId,
+            finalResults,
+            roomMemberIdByUserId: patched.roomMemberIdByUserId,
+          });
+        }
+
+        const { totalScores, ...rest } = patched as any;
 
         this.eventPublisher.broadcastGameState(roomId, {
-          ...patched,
-          finalScoresByUserId,
+          ...rest,
+          finalResults,
+          finalRewards,
         });
 
-        this.scheduleReturnToWaitingAfterFinished(roomId);
-
+        this.finishedReturnService.schedule(roomId);
         return;
       }
 
@@ -519,51 +537,31 @@ export class GameSessionService {
     return out;
   }
 
-  private scheduleReturnToWaitingAfterFinished(roomId: number) {
-    // room당 1개만 유지
-    this.clearFinishedReturnTimer(roomId);
+  private buildFinalResults(finalScoresByUserId: Record<string, number>) {
+    const items = Object.entries(finalScoresByUserId)
+      .map(([userId, score]) => ({ userId: Number(userId), score: Number(score) }))
+      .sort((a, b) => b.score - a.score);
 
-    const timer = setTimeout(() => {
-      void (async () => {
-        try {
-          const current = await this.gameStateStore.get(roomId);
-          if (!current) return;
+    const out: Array<{ userId: number; score: number; placement: number }> = [];
 
-          // 아직 FINISHED일 때만 대기실로 전환
-          if (current.phase !== GamePhase.FINISHED) return;
+    let prevScore: number | null = null;
+    let prevPlacement = 0;
 
-          // 다른 phase 전환 타이머가 남아있을 수 있으니 정리
-          this.clearPhaseTimer(roomId);
+    for (let i = 0; i < items.length; i++) {
+      const { userId, score } = items[i];
 
-          const patched = await this.gameStateStore.patch(roomId, {
-            phase: GamePhase.WAITING, // ✅ 실제 대기 phase로 변경(예: LOBBY)
-            endsAt: null,
-            phaseContext: null,
-            currentTheme: null,
-          });
+      let placement: number;
+      if (prevScore !== null && score === prevScore) {
+        placement = prevPlacement;
+      } else {
+        placement = i + 1;
+        prevScore = score;
+        prevPlacement = placement;
+      }
 
-          if (!patched) return;
+      out.push({ userId, score, placement });
+    }
 
-          // eventPublisher가 내부적으로 server.to(...).emit(...) 하므로 server 인자 불필요
-          this.eventPublisher.broadcastGameState(roomId, patched);
-        } catch (error: unknown) {
-          if (error instanceof Error) {
-            this.logger.error(
-              { message: error.message, stack: error.stack, roomId },
-              'scheduleReturnToWaitingAfterFinished timeout handler failed',
-            );
-          } else {
-            this.logger.error(
-              { error, roomId },
-              'scheduleReturnToWaitingAfterFinished timeout handler failed (non-Error thrown)',
-            );
-          }
-        } finally {
-          this.clearFinishedReturnTimer(roomId);
-        }
-      })();
-    }, FINISHED_HOLD_MS);
-
-    this.finishedReturnTimersByRoomId.set(roomId, timer);
+    return out;
   }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #140 

## 📝 작업 내용

-  `updateGameState(WAITING)` 브로드캐스트
- 매치 종료 처리 시점에 보상 확정
- 중복 지급 방지 설계 적용
- MatchResult에 결과 저장
UserProfile 업데이트 로직 반영
Room 업데이트 로직 반영